### PR TITLE
Allow multiple category selection in transaction table filter

### DIFF
--- a/src/locales/bn.json
+++ b/src/locales/bn.json
@@ -67,6 +67,7 @@
     "chinese": "চীনা",
     "clearFilters": "ফিল্টার সাফ করুন",
     "clearSelection": "নির্বাচন সাফ করুন",
+    "selected": "নির্বাচিত",
     "current": "বর্তমান",
     "date": "তারিখ",
     "delete": "মুছুন",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,6 +67,7 @@
     "chinese": "中文",
     "clearFilters": "Clear filters",
     "clearSelection": "Clear selection",
+    "selected": "selected",
     "current": "current",
     "date": "Date",
     "delete": "Delete",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -67,6 +67,7 @@
     "chinese": "Chino",
     "clearFilters": "Borrar filtros",
     "clearSelection": "Quitar selección",
+    "selected": "seleccionados",
     "current": "actual",
     "date": "Fecha",
     "delete": "Eliminar",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -67,6 +67,7 @@
     "chinese": "चीनी",
     "clearFilters": "फ़िल्टर साफ़ करें",
     "clearSelection": "चयन साफ़ करें",
+    "selected": "चयनित",
     "current": "वर्तमान",
     "date": "तारीख",
     "delete": "हटाएं",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -67,6 +67,7 @@
     "chinese": "中国語",
     "clearFilters": "フィルタをクリア",
     "clearSelection": "選択をクリア",
+    "selected": "件選択中",
     "current": "現在",
     "date": "日付",
     "delete": "削除",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -67,6 +67,7 @@
     "chinese": "중국어",
     "clearFilters": "필터 지우기",
     "clearSelection": "선택 지우기",
+    "selected": "개 선택됨",
     "current": "현재",
     "date": "날짜",
     "delete": "삭제",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -67,6 +67,7 @@
     "chinese": "中文",
     "clearFilters": "清除筛选",
     "clearSelection": "清除选择",
+    "selected": "已选择",
     "current": "当前",
     "date": "日期",
     "delete": "删除",

--- a/src/pages/transactions/FiltersAndActionsDialog.tsx
+++ b/src/pages/transactions/FiltersAndActionsDialog.tsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CategoryOption } from "@/lib/categoryColors";
 import type { ExpenseSource } from "@/types/core";
 import type { FiltersAndActionsDialogProps } from "@/types/transactions";
@@ -123,30 +124,55 @@ export function FiltersAndActionsDialog({
                 <Label className="text-muted-foreground">
                   {t("common.category")}
                 </Label>
-                <Select
-                  value={categoryFilter || "_"}
-                  onValueChange={(v) =>
-                    onCategoryFilterChange(v === "_" ? "" : v)
-                  }
-                >
-                  <SelectTrigger className={selectTriggerClass}>
-                    <SelectValue placeholder={t("common.all")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="_">{t("common.all")}</SelectItem>
-                    <SelectItem value="__uncategorized">
-                      <CategoryOption
-                        name={t("common.uncategorized")}
-                        type="expense"
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className={`${selectTriggerClass} flex items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs`}
+                    >
+                      <span className="truncate text-left">
+                        {categoryFilter.length === 0
+                          ? t("common.all")
+                          : categoryFilter.length === 1
+                            ? (categoryFilter[0] === "__uncategorized"
+                                ? t("common.uncategorized")
+                                : categoryFilter[0])
+                            : `${categoryFilter.length} ${t("common.selected")}`}
+                      </span>
+                      <svg className="size-4 shrink-0 opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-1 max-h-64 overflow-y-auto" align="start">
+                    <label className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm cursor-pointer hover:bg-accent">
+                      <Checkbox
+                        checked={categoryFilter.includes("__uncategorized")}
+                        onCheckedChange={(checked) => {
+                          if (checked) {
+                            onCategoryFilterChange([...categoryFilter, "__uncategorized"]);
+                          } else {
+                            onCategoryFilterChange(categoryFilter.filter((c) => c !== "__uncategorized"));
+                          }
+                        }}
                       />
-                    </SelectItem>
+                      <CategoryOption name={t("common.uncategorized")} type="expense" />
+                    </label>
                     {expenseCategories.map((c) => (
-                      <SelectItem key={c} value={c}>
+                      <label key={c} className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm cursor-pointer hover:bg-accent">
+                        <Checkbox
+                          checked={categoryFilter.includes(c)}
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              onCategoryFilterChange([...categoryFilter, c]);
+                            } else {
+                              onCategoryFilterChange(categoryFilter.filter((v) => v !== c));
+                            }
+                          }}
+                        />
                         <CategoryOption name={c} type="expense" />
-                      </SelectItem>
+                      </label>
                     ))}
-                  </SelectContent>
-                </Select>
+                  </PopoverContent>
+                </Popover>
               </div>
               <div className="space-y-2">
                 <Label className="text-muted-foreground">

--- a/src/pages/transactions/TransactionsPage.tsx
+++ b/src/pages/transactions/TransactionsPage.tsx
@@ -44,7 +44,7 @@ export function TransactionsPage() {
   } = useBudget();
   const [monthFilter, setMonthFilter] = useState<string>("");
   const [sourceFilter, setSourceFilter] = useState<string>("all");
-  const [categoryFilter, setCategoryFilter] = useState<string>("");
+  const [categoryFilter, setCategoryFilter] = useState<string[]>([]);
   const [searchFilter, setSearchFilter] = useState<string>("");
   const [ownerFilter, setOwnerFilter] = useState<string>("all");
   const [typeFilter, setTypeFilter] = useState<"all" | "expense" | "transfer">("all");
@@ -81,7 +81,8 @@ export function TransactionsPage() {
     const params = new URLSearchParams(location.search);
     setMonthFilter(params.get("month") ?? "");
     setSourceFilter(params.get("source") ?? "all");
-    setCategoryFilter(params.get("category") ?? "");
+    const categoryParam = params.get("category") ?? "";
+    setCategoryFilter(categoryParam ? categoryParam.split(",") : []);
     setOwnerFilter(params.get("owner") ?? "all");
     const nextType = params.get("type");
     setTypeFilter(
@@ -154,7 +155,7 @@ export function TransactionsPage() {
   const clearFilters = useCallback(() => {
     setMonthFilter("");
     setSourceFilter("all");
-    setCategoryFilter("");
+    setCategoryFilter([]);
     setSearchFilter("");
     setOwnerFilter("all");
     setTypeFilter("all");

--- a/src/pages/transactions/transactionsLedger.ts
+++ b/src/pages/transactions/transactionsLedger.ts
@@ -17,7 +17,7 @@ export type TransactionTypeFilter = "all" | "expense" | "transfer";
 export interface TransactionFilterState {
   monthFilter: string;
   sourceFilter: string;
-  categoryFilter: string;
+  categoryFilter: string[];
   searchFilter: string;
   ownerFilter: string;
   typeFilter: TransactionTypeFilter;
@@ -110,12 +110,15 @@ export function filterAndSortTransactionRows({
     list = list.filter((row) => row.kind !== "expense" || row.source === sourceFilter);
   }
 
-  if (categoryFilter) {
-    if (categoryFilter === "__uncategorized") {
-      list = list.filter((row) => row.kind === "expense" && !row.category);
-    } else {
-      list = list.filter((row) => row.kind === "expense" && row.category === categoryFilter);
-    }
+  if (categoryFilter.length > 0) {
+    const hasUncategorized = categoryFilter.includes("__uncategorized");
+    const namedCategories = categoryFilter.filter((c) => c !== "__uncategorized");
+    list = list.filter((row) => {
+      if (row.kind !== "expense") return false;
+      if (hasUncategorized && !row.category) return true;
+      if (namedCategories.length > 0 && namedCategories.includes(row.category ?? "")) return true;
+      return false;
+    });
   }
 
   if (searchFilter.trim()) {
@@ -236,7 +239,7 @@ export function hasActiveTransactionFilters(filters: TransactionFilterState): bo
   return Boolean(
     filters.monthFilter ||
       filters.sourceFilter !== "all" ||
-      filters.categoryFilter ||
+      filters.categoryFilter.length > 0 ||
       filters.searchFilter.trim() ||
       filters.ownerFilter !== "all" ||
       filters.typeFilter !== "all",

--- a/src/types/transactions-ui.ts
+++ b/src/types/transactions-ui.ts
@@ -38,8 +38,8 @@ export interface FiltersAndActionsDialogProps {
   onMonthFilterChange: (value: string) => void;
   sourceFilter: string;
   onSourceFilterChange: (value: string) => void;
-  categoryFilter: string;
-  onCategoryFilterChange: (value: string) => void;
+  categoryFilter: string[];
+  onCategoryFilterChange: (value: string[]) => void;
   ownerFilter: string;
   onOwnerFilterChange: (value: string) => void;
   typeFilter: "all" | "expense" | "transfer";

--- a/test/pages/TransactionsPage.test.tsx
+++ b/test/pages/TransactionsPage.test.tsx
@@ -211,7 +211,7 @@ test("TransactionsPage supports sorting branches and row tap actions", () => {
   });
   expect(deleteDialog).toBeInTheDocument();
   fireEvent.click(within(deleteDialog).getByRole("button", { name: "Cancel" }));
-});
+}, { timeout: 15000 });
 
 test("TransactionsPage shows empty state when no valid non-mortgage expenses", () => {
   seedBudget([

--- a/test/pages/transactions/FiltersAndActionsDialog.test.tsx
+++ b/test/pages/transactions/FiltersAndActionsDialog.test.tsx
@@ -14,7 +14,7 @@ test("FiltersAndActionsDialog shows title and Filters section when open", () => 
       onMonthFilterChange={() => {}}
       sourceFilter="all"
       onSourceFilterChange={() => {}}
-      categoryFilter=""
+      categoryFilter={[]}
       onCategoryFilterChange={() => {}}
       ownerFilter="all"
       onOwnerFilterChange={() => {}}
@@ -45,7 +45,7 @@ test("FiltersAndActionsDialog month picker updates month filter", () => {
       onMonthFilterChange={onMonthFilterChange}
       sourceFilter="all"
       onSourceFilterChange={() => {}}
-      categoryFilter=""
+      categoryFilter={[]}
       onCategoryFilterChange={() => {}}
       ownerFilter="all"
       onOwnerFilterChange={() => {}}

--- a/test/pages/transactions/transactionsLedger.test.ts
+++ b/test/pages/transactions/transactionsLedger.test.ts
@@ -31,7 +31,7 @@ test("owner filter uses allocation-aware expense amounts and signed transfer imp
     filters: {
       monthFilter: "",
       sourceFilter: "all",
-      categoryFilter: "",
+      categoryFilter: [],
       searchFilter: "",
       ownerFilter: "Tasnuva",
       typeFilter: "all",
@@ -46,7 +46,7 @@ test("owner filter uses allocation-aware expense amounts and signed transfer imp
     filters: {
       monthFilter: "",
       sourceFilter: "all",
-      categoryFilter: "",
+      categoryFilter: [],
       searchFilter: "",
       ownerFilter: "Ayaz",
       typeFilter: "all",


### PR DESCRIPTION
Change the category filter from single-select to multi-select using a Popover with checkboxes, enabling users to filter by multiple categories simultaneously. Also increase timeout on flaky sorting test.

https://claude.ai/code/session_01KbP2JXmnCFLhBEZ2fswiuG