### PR TITLE
refactor: redesign Manage Widgets sheet with DS components and catego…

### DIFF
--- a/src/components/ds/DsWidgetCatalog.tsx
+++ b/src/components/ds/DsWidgetCatalog.tsx
@@ -1,16 +1,13 @@
 import { useTranslation } from "react-i18next";
-import { Plus, Check, RotateCcw } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { DsSheetHeader } from "@/components/ds/DsSheetHeader";
+import { DsSheetActions } from "@/components/ds/DsSheetActions";
+import { DsDataRow } from "@/components/ds/DsDataRow";
 import { WIDGET_REGISTRY } from "@/lib/widgets/widgetRegistry";
-import { ALL_WIDGET_TYPES } from "@/lib/widgets/defaultLayout";
+import { WIDGET_GROUPS } from "@/lib/widgets/widgetGroups";
 import type { WidgetType } from "@/lib/widgets/widget";
 
 interface DsWidgetCatalogProps {
@@ -34,53 +31,47 @@ export function DsWidgetCatalog({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="flex flex-col w-80 sm:w-96 px-5">
-        <SheetHeader>
-          <SheetTitle>{t("widget.manageWidgets")}</SheetTitle>
-          <SheetDescription>{t("widget.catalogDescription")}</SheetDescription>
-        </SheetHeader>
-        <div className="flex-1 mt-4 space-y-1 overflow-y-auto">
-          {ALL_WIDGET_TYPES.map((wType) => {
-            const entry = WIDGET_REGISTRY[wType];
-            if (!entry) return null;
-            const isVisible = visibleWidgetIds.has(wType);
-
-            return (
-              <div
-                key={wType}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-muted/50"
-              >
-                <span className="shrink-0 text-muted-foreground">{entry.icon}</span>
-                <span className="flex-1 text-sm font-medium truncate">
-                  {t(entry.label)}
-                </span>
-                {isVisible ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 gap-1.5 text-xs text-muted-foreground"
-                    onClick={() => onHide(wType)}
-                  >
-                    <Check className="size-3.5" />
-                    {t("widget.visible")}
-                  </Button>
-                ) : (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 gap-1.5 text-xs"
-                    onClick={() => onShow(wType)}
-                  >
-                    <Plus className="size-3.5" />
-                    {t("widget.addWidget")}
-                  </Button>
-                )}
+      <SheetContent side="right" className="flex flex-col p-0 gap-0 w-80 sm:w-96">
+        <DsSheetHeader
+          title={t("widget.manageWidgets")}
+          description={t("widget.catalogDescription")}
+        />
+        <div className="flex-1 overflow-y-auto">
+          {WIDGET_GROUPS.map((group) => (
+            <div key={group.key}>
+              <div className="sticky top-0 z-10 bg-[var(--surface-1)] px-4 py-2 border-b border-[var(--border-subtle)]">
+                <span className="ds-label text-muted-foreground">{t(group.label)}</span>
               </div>
-            );
-          })}
+              {group.widgets.map((wType) => {
+                const entry = WIDGET_REGISTRY[wType];
+                if (!entry) return null;
+                const isVisible = visibleWidgetIds.has(wType);
+
+                return (
+                  <DsDataRow
+                    key={wType}
+                    dense
+                    leading={
+                      <span className="text-muted-foreground">{entry.icon}</span>
+                    }
+                    title={t(entry.label)}
+                    trailing={
+                      <Switch
+                        checked={isVisible}
+                        onCheckedChange={(checked) =>
+                          checked ? onShow(wType) : onHide(wType)
+                        }
+                        aria-label={t(entry.label)}
+                      />
+                    }
+                  />
+                );
+              })}
+            </div>
+          ))}
         </div>
         {onReset && (
-          <SheetFooter className="border-t pt-4">
+          <DsSheetActions>
             <Button
               variant="outline"
               className="w-full gap-2"
@@ -89,7 +80,7 @@ export function DsWidgetCatalog({
               <RotateCcw className="size-4" />
               {t("widget.resetLayout")}
             </Button>
-          </SheetFooter>
+          </DsSheetActions>
         )}
       </SheetContent>
     </Sheet>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/lib/widgets/index.ts
+++ b/src/lib/widgets/index.ts
@@ -13,3 +13,6 @@ export type { CreateWidgetOptions } from "./createWidget";
 export { DEFAULT_LAYOUT, ALL_WIDGET_TYPES } from "./defaultLayout";
 
 export { WIDGET_REGISTRY } from "./widgetRegistry";
+
+export { WIDGET_GROUPS } from "./widgetGroups";
+export type { WidgetGroup } from "./widgetGroups";

--- a/src/lib/widgets/widgetGroups.ts
+++ b/src/lib/widgets/widgetGroups.ts
@@ -1,0 +1,30 @@
+import type { WidgetType } from "@/lib/widgets/widget";
+
+export interface WidgetGroup {
+  key: string;
+  label: string;
+  widgets: WidgetType[];
+}
+
+export const WIDGET_GROUPS: WidgetGroup[] = [
+  {
+    key: "kpi",
+    label: "widget.groupKpiMetrics",
+    widgets: ["net-cash-flow", "total-spent", "total-income", "total-debt"],
+  },
+  {
+    key: "charts",
+    label: "widget.groupCharts",
+    widgets: ["cash-flow-chart", "net-trend-chart", "category-chart", "owner-split-chart"],
+  },
+  {
+    key: "lists",
+    label: "widget.groupListsActivity",
+    widgets: ["quick-add", "debt-snapshot", "spend-by-source", "owner-transfers", "recent-activity"],
+  },
+  {
+    key: "insights",
+    label: "widget.groupInsights",
+    widgets: ["smart-insights"],
+  },
+];

--- a/src/locales/bn.json
+++ b/src/locales/bn.json
@@ -821,6 +821,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -843,6 +843,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -822,6 +822,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -821,6 +821,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -821,6 +821,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -821,6 +821,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -822,6 +822,10 @@
     "addWidget": "Add",
     "catalogDescription": "Toggle widgets on or off",
     "moveUp": "Move up",
+    "groupKpiMetrics": "KPI Metrics",
+    "groupCharts": "Charts",
+    "groupListsActivity": "Lists & Activity",
+    "groupInsights": "Insights",
     "moveDown": "Move down"
   }
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -152,6 +152,16 @@ function DashboardContent() {
         <Button
           variant="secondary"
           density="compact"
+          onClick={() => setCatalogOpen(true)}
+          className="rounded-full p-0"
+          size="icon"
+          aria-label={tWidget("widget.manageWidgets")}
+        >
+          <Grid2X2 className="size-4" />
+        </Button>
+        <Button
+          variant="secondary"
+          density="compact"
           onClick={() => data.setSettingsOpen(true)}
           className="rounded-full p-0"
           size="icon"


### PR DESCRIPTION
…ry groups

Replace raw shadcn Sheet primitives with DsSheetHeader, DsSheetActions, and DsDataRow. Group 14 widgets into 4 categories (KPI Metrics, Charts, Lists & Activity, Insights) with sticky section headers. Swap ghost/outline toggle buttons for Switch component. Add Grid2X2 button to mobile action bar so the catalog is accessible on all viewports.