### PR TITLE
fix: FX rate fallback warning banner (#72)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
-import { Landmark, CircleHelp } from "lucide-react";
-import { useGoogleAuth } from "@/context";
+import { Landmark, CircleHelp, AlertTriangle, X } from "lucide-react";
+import { useGoogleAuth, useBudget } from "@/context";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
@@ -37,6 +37,13 @@ export function Layout() {
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
+  const { uiFormatSettings } = useBudget();
+  const [fxWarningDismissed, setFxWarningDismissed] = useState(false);
+  const showFxWarning =
+    !fxWarningDismissed &&
+    uiFormatSettings.currency !== "USD" &&
+    uiFormatSettings.fxFallback === true &&
+    uiFormatSettings.fxRate === 1;
   const {
     isSignedIn,
     userProfile,
@@ -230,6 +237,20 @@ export function Layout() {
         )}
       >
         <div className="mx-auto w-full max-w-7xl flex-1 flex flex-col min-w-0">
+          {showFxWarning && (
+            <div className="flex items-center gap-2 rounded-lg bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 px-3 py-2 mx-4 mt-3 md:mx-0 md:mt-0 md:mb-4 text-sm text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="size-4 shrink-0" />
+              <span className="flex-1">{t("layout.fxUnavailable")}</span>
+              <button
+                type="button"
+                onClick={() => setFxWarningDismissed(true)}
+                className="shrink-0 rounded p-0.5 hover:bg-amber-200/50 dark:hover:bg-amber-800/50"
+                aria-label="Dismiss"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          )}
           <Outlet />
         </div>
       </main>

--- a/src/lib/platform/fx.ts
+++ b/src/lib/platform/fx.ts
@@ -119,6 +119,9 @@ export async function getUsdFxRate(currency: SupportedCurrency): Promise<{
       if (cached) {
         return { rate: cached.rate, asOf: cached.asOf, fallback: true };
       }
+      console.warn(
+        `[fx] FX rate fetch failed for ${currency} with no cache — using fallback rate 1:1`,
+      );
       return {
         rate: FALLBACK_RATE,
         asOf: new Date().toISOString(),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -465,7 +465,8 @@
     "openMenu": "Open menu",
     "collapse": "Collapse",
     "signIn": "Sign in with Google",
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "fxUnavailable": "Currency conversion unavailable — amounts shown as 1:1 with USD"
   },
   "mortgage": {
     "addMortgagePayment": "Add mortgage payment",

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -84,6 +84,7 @@ function renderLayout(
 afterEach(() => {
   cleanup();
   localStorage.removeItem("budget-tool-help-hint-seen");
+  localStorage.removeItem("budget-tool-ui-format");
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: originalMatchMedia,
@@ -208,4 +209,52 @@ test("Layout shows help hint after sheet setup flow is resolved for first-time u
     expect(screen.getByText("Need help in the app?")).toBeInTheDocument();
   });
   expect(screen.getByRole("button", { name: "Got it" })).toBeInTheDocument();
+});
+
+test("Layout shows FX fallback warning when rate is 1 and fxFallback is true for non-USD currency", () => {
+  localStorage.setItem(
+    "budget-tool-ui-format",
+    JSON.stringify({
+      locale: "en-US",
+      currency: "EUR",
+      baseCurrency: "USD",
+      fxRate: 1,
+      fxFallback: true,
+      dateFormat: "YYYY/MM/DD",
+    }),
+  );
+  renderLayout();
+  expect(screen.getByText(/currency conversion unavailable/i)).toBeInTheDocument();
+});
+
+test("Layout does not show FX warning when currency is USD", () => {
+  localStorage.setItem(
+    "budget-tool-ui-format",
+    JSON.stringify({
+      locale: "en-US",
+      currency: "USD",
+      baseCurrency: "USD",
+      fxRate: 1,
+      fxFallback: false,
+      dateFormat: "YYYY/MM/DD",
+    }),
+  );
+  renderLayout();
+  expect(screen.queryByText(/currency conversion unavailable/i)).not.toBeInTheDocument();
+});
+
+test("Layout does not show FX warning when fxFallback is true but rate is not 1", () => {
+  localStorage.setItem(
+    "budget-tool-ui-format",
+    JSON.stringify({
+      locale: "en-US",
+      currency: "EUR",
+      baseCurrency: "USD",
+      fxRate: 0.92,
+      fxFallback: true,
+      dateFormat: "YYYY/MM/DD",
+    }),
+  );
+  renderLayout();
+  expect(screen.queryByText(/currency conversion unavailable/i)).not.toBeInTheDocument();
 });

--- a/test/lib/fx.test.ts
+++ b/test/lib/fx.test.ts
@@ -62,6 +62,25 @@ describe("fx", () => {
     expect(fx.fallback).toBe(false);
   });
 
+  test("logs console.warn when falling back to rate 1 with no cache", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    globalThis.fetch = mock(async () => {
+      return new Response("fail", { status: 500 }) as unknown as Response;
+    }) as typeof fetch;
+
+    const fx = await getUsdFxRate("GBP");
+    expect(fx.rate).toBe(1);
+    expect(fx.fallback).toBe(true);
+    expect(warnings.some((w) => w.includes("GBP"))).toBe(true);
+
+    console.warn = originalWarn;
+  });
+
   test("fetches rates for all newly added currencies", async () => {
     const currencies: DisplayCurrency[] = [
       "CAD",


### PR DESCRIPTION
## Summary
- Added `console.warn` when FX rate falls back to 1:1 with no cache
- Added dismissible amber warning banner in Layout when FX conversion is unavailable
- Banner only shows when currency is non-USD, `fxFallback` is true, AND rate is 1 (worst case — no cache)
- Stale cache fallback (rate !== 1) is a less severe case already shown in Settings

## Test plan
- [x] FX test: console.warn fires on no-cache fallback
- [x] Layout test: banner appears when fxFallback=true, rate=1, currency=EUR
- [x] Layout test: banner hidden when currency=USD
- [x] Layout test: banner hidden when fxFallback=true but rate !== 1 (stale cache)
- [x] All 586 tests pass, build green

Closes #72

Generated with [Claude Code](https://claude.com/claude-code)