### PR TITLE
fix: CSV parser returns clear error for unknown formats

### DIFF
--- a/src/lib/parsers/index.ts
+++ b/src/lib/parsers/index.ts
@@ -33,7 +33,7 @@ export function parseCsv(csvText: string, source?: CsvSource): ParseResult {
     case "apple":
       return parseAppleCsv(cleanText);
     default:
-      return { expenses: [], source: "amex" };
+      return { expenses: [], source: "manual", error: "unknown-format" };
   }
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -390,6 +390,7 @@
     "duplicatesSkipped": "{{count}} duplicates skipped",
     "exportedPdfInvalid": "This doesn't look like an exported transactions PDF.",
     "pdfImportFailed": "PDF import failed",
+    "unknownCsvFormat": "Unrecognized CSV format. Please select the correct source or use a supported bank export.",
     "importFailed": "Import failed",
     "exportStringPasteFirst": "Paste an export string first.",
     "exportStringNotRecognized": "Export string not recognized.",

--- a/src/pages/import/useImportState.ts
+++ b/src/pages/import/useImportState.ts
@@ -398,6 +398,14 @@ export function useImportState() {
           const csvSource: CsvSource =
             state.selectedSource === "amex" ? "amex" : (state.selectedSource as CsvSource);
           const result = parseCsv(text, csvSource);
+          if (result.error) {
+            dispatch({
+              type: "SET_IMPORT_ERROR",
+              payload: t("import.unknownCsvFormat"),
+            });
+            dispatch({ type: "CLEAR_PREVIEW" });
+            return;
+          }
           let toAdd = filterOutExistingExpenses(result.expenses, expenses);
           if (state.selectedSource === "amex") {
             const source =

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -95,6 +95,7 @@ export interface PresetTransaction {
 export interface ParseResult {
   expenses: Expense[];
   source: ExpenseSource;
+  error?: string;
 }
 
 export const DEFAULT_EXPENSE_CATEGORIES = [

--- a/test/lib/parsers/index.test.ts
+++ b/test/lib/parsers/index.test.ts
@@ -38,9 +38,24 @@ test("parseCsv with amex source parses expenses", () => {
   expect(result.expenses[0]!.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 });
 
-test("parseCsv unknown returns empty", () => {
+test("parseCsv unknown returns empty with error and source manual", () => {
   const result = parseCsv("a,b,c", "unknown");
   expect(result.expenses).toEqual([]);
+  expect(result.source).toBe("manual");
+  expect(result.error).toBe("unknown-format");
+});
+
+test("parseCsv chase returns empty with error (no chase parser)", () => {
+  const result = parseCsv("a,b,c", "chase");
+  expect(result.expenses).toEqual([]);
+  expect(result.source).toBe("manual");
+  expect(result.error).toBe("unknown-format");
+});
+
+test("parseCsv auto-detects unknown CSV and returns error", () => {
+  const result = parseCsv("foo,bar,baz\n1,2,3");
+  expect(result.expenses).toEqual([]);
+  expect(result.error).toBe("unknown-format");
 });
 
 test("parseAmexCsv requires date description amount columns", () => {


### PR DESCRIPTION
## Summary
- When `detectCsvSource()` returns `unknown`, `parseCsv()` now returns `{ expenses: [], source: "manual", error: "unknown-format" }` instead of the misleading `{ expenses: [], source: "amex" }`
- Added `error?: string` field to `ParseResult` type
- `useImportState` checks `result.error` and surfaces a descriptive error message to the user
- Added 3 new tests covering unknown, chase, and auto-detected unknown CSV formats

Closes #73

## Test plan
- [x] `parseCsv("a,b,c", "unknown")` returns `source: "manual"` and `error: "unknown-format"`
- [x] `parseCsv("a,b,c", "chase")` returns same error (no chase parser yet)
- [x] `parseCsv("foo,bar,baz\n1,2,3")` auto-detects unknown and returns error
- [x] Existing amex and apple parser tests still pass
- [x] Full test suite passes (588 pass, 0 fail)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)