### PR TITLE
fix: add owner-expense-by-owner to WIDGET_GROUPS

### DIFF
--- a/src/lib/widgets/widgetGroups.ts
+++ b/src/lib/widgets/widgetGroups.ts
@@ -15,7 +15,7 @@ export const WIDGET_GROUPS: WidgetGroup[] = [
   {
     key: "charts",
     label: "widget.groupCharts",
-    widgets: ["cash-flow-chart", "net-trend-chart", "category-chart", "owner-split-chart"],
+    widgets: ["cash-flow-chart", "net-trend-chart", "category-chart", "owner-split-chart", "owner-expense-by-owner"],
   },
   {
     key: "lists",

--- a/test/lib/widgetGroups.test.ts
+++ b/test/lib/widgetGroups.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { WIDGET_GROUPS } from "@/lib/widgets/widgetGroups";
+import { WIDGET_REGISTRY } from "@/lib/widgets/widgetRegistry";
+
+test("every registered widget type appears in at least one WIDGET_GROUPS category", () => {
+  const allGroupedWidgets = WIDGET_GROUPS.flatMap((g) => g.widgets);
+  const registeredTypes = Object.keys(WIDGET_REGISTRY);
+
+  for (const type of registeredTypes) {
+    expect(allGroupedWidgets).toContain(type);
+  }
+});
+
+test("owner-expense-by-owner is in the charts group", () => {
+  const chartsGroup = WIDGET_GROUPS.find((g) => g.key === "charts");
+  expect(chartsGroup).toBeDefined();
+  expect(chartsGroup!.widgets).toContain("owner-expense-by-owner");
+});


### PR DESCRIPTION
## Summary
- Added `owner-expense-by-owner` widget to the `charts` group in `WIDGET_GROUPS`
- Added test ensuring every registered widget appears in at least one group

Closes #74

## Test plan
- [x] Every widget in `WIDGET_REGISTRY` is present in at least one `WIDGET_GROUPS` category
- [x] `owner-expense-by-owner` specifically in the `charts` group
- [x] Full test suite passes (590 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)