### PR TITLE
feat: add timeout to Google API and sync operations

### DIFF
--- a/src/context/SyncContext.tsx
+++ b/src/context/SyncContext.tsx
@@ -23,6 +23,7 @@ import { isMortgageCategory } from "@/lib/domain/mortgageCategory";
 import { isDisplayCurrency } from "@/types/currency";
 import { isSpreadsheetActive } from "@/lib/google/googleDrive";
 import { storage, STORAGE_KEYS } from "@/lib/platform/storage";
+import { withTimeout, TimeoutError } from "@/lib/platform/withTimeout";
 import type { SyncHealth, SyncStatus } from "@/types/auth";
 
 // ---------------------------------------------------------------------------
@@ -33,6 +34,7 @@ const AUTO_SYNC_DEBOUNCE_MS = 2_000;
 const AUTO_SYNC_INTERVAL_MS = 5 * 60_000;
 const SYNC_RATE_LIMIT_BASE_DELAY_MS = 3_000;
 const SYNC_RATE_LIMIT_MAX_DELAY_MS = 30_000;
+const SYNC_TIMEOUT_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Sync state machine (replaces 10+ useRef declarations)
@@ -319,7 +321,7 @@ export function SyncProvider({
     try {
       const snapshot = getSyncSnapshot();
       const db = createSheetsClient(spreadsheetId, async () => accessToken);
-      await db.ensureSchema();
+      await withTimeout(db.ensureSchema(), SYNC_TIMEOUT_MS);
       const nonMortgageExpenses = snapshot.expenses.filter(
         (e) => !isMortgageCategory(e.category),
       );
@@ -348,7 +350,7 @@ export function SyncProvider({
         owners: snapshot.owners,
       });
       const grand = computeGrandTotals(months);
-      await db.batchSync({
+      await withTimeout(db.batchSync({
         expenses: nonMortgageExpenses.map((e) => ({
           id: e.id,
           date: e.date,
@@ -403,11 +405,11 @@ export function SyncProvider({
           category: p.category || "Uncategorized",
           owner: p.owner,
         })),
-      });
+      }), SYNC_TIMEOUT_MS);
       // Data blob and Totals are special cases — written separately
-      await writeDataBlob(db, dataBlob);
-      await writeTotalsSheet(db, months, grand);
-      await db.applyFormatting();
+      await withTimeout(writeDataBlob(db, dataBlob), SYNC_TIMEOUT_MS);
+      await withTimeout(writeTotalsSheet(db, months, grand), SYNC_TIMEOUT_MS);
+      await withTimeout(db.applyFormatting(), SYNC_TIMEOUT_MS);
       lastSyncedSignatureRef.current = snapshot.signature;
       const changed =
         latestSyncSignatureRef.current !== lastSyncedSignatureRef.current;
@@ -420,7 +422,13 @@ export function SyncProvider({
       nextSyncAllowedAtRef.current = 0;
     } catch (err) {
       console.error("Sync failed:", err);
-      if (isGenjutsuError(err)) {
+      if (err instanceof TimeoutError) {
+        dispatchSync({
+          type: "SYNC_ERROR",
+          message: i18n.t("auth.syncTimedOut"),
+          health: "warning",
+        });
+      } else if (isGenjutsuError(err)) {
         switch (err.kind) {
           case "AUTH_ERROR":
             clearSession();
@@ -611,7 +619,7 @@ export function SyncProvider({
     dispatchSync({ type: "START_SYNC" });
     try {
       const db = createSheetsClient(spreadsheetId, async () => accessToken);
-      await db.ensureSchema();
+      await withTimeout(db.ensureSchema(), SYNC_TIMEOUT_MS);
 
       // Helper: read all 7 domain sheets via genjutsu-db and convert to app types
       const readFromSheetTabs = async () => {
@@ -771,7 +779,7 @@ export function SyncProvider({
       let sheetOwnerTransfers: typeof budget.ownerTransfers;
       let sheetPresets: typeof presetTransactions;
 
-      const blob = await readDataBlob(db);
+      const blob = await withTimeout(readDataBlob(db), SYNC_TIMEOUT_MS);
       if (blob && blob.startsWith("V2")) {
         try {
           const expanded = parseFromBlob(blob);
@@ -960,7 +968,13 @@ export function SyncProvider({
       lastSyncedSignatureRef.current = latestSyncSignatureRef.current;
     } catch (err) {
       console.error("Restore from sheet failed:", err);
-      if (isGenjutsuError(err)) {
+      if (err instanceof TimeoutError) {
+        dispatchSync({
+          type: "SYNC_ERROR",
+          message: i18n.t("auth.syncTimedOut"),
+          health: "warning",
+        });
+      } else if (isGenjutsuError(err)) {
         switch (err.kind) {
           case "AUTH_ERROR":
             clearSession();

--- a/src/lib/google/googleDrive.ts
+++ b/src/lib/google/googleDrive.ts
@@ -1,5 +1,8 @@
+import { withTimeout } from "@/lib/platform/withTimeout";
+
 const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
 const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const API_TIMEOUT_MS = 30_000;
 
 export const ORTHO_FOLDER_NAME = "Ortho";
 export const ORTHO_SHEET_NAME = "Ortho Budget";
@@ -12,14 +15,17 @@ async function driveRequest<T>(
   url: string,
   init?: RequestInit,
 ): Promise<T> {
-  const res = await fetch(url, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-      ...(init?.headers ?? {}),
-    },
-  });
+  const res = await withTimeout(
+    fetch(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    }),
+    API_TIMEOUT_MS,
+  );
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`Drive API failed: ${res.status} ${body}`);
@@ -133,16 +139,19 @@ export async function createSheetInFolder(
   folderId: string,
   sheetName: string,
 ): Promise<{ id: string; name: string }> {
-  const createRes = await fetch(SHEETS_API, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      properties: { title: sheetName },
+  const createRes = await withTimeout(
+    fetch(SHEETS_API, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        properties: { title: sheetName },
+      }),
     }),
-  });
+    API_TIMEOUT_MS,
+  );
   if (!createRes.ok) {
     const body = await createRes.text();
     throw new Error(`Sheets API failed: ${createRes.status} ${body}`);

--- a/src/lib/platform/withTimeout.ts
+++ b/src/lib/platform/withTimeout.ts
@@ -1,0 +1,18 @@
+export class TimeoutError extends Error {
+  constructor(message = "Operation timed out") {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new TimeoutError()), ms),
+    ),
+  ]);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,7 +52,8 @@
     "signInWithGoogle": "Google",
     "valuePropSubtitle": "Sync with Google Sheets. No credit card needed.",
     "valuePropTitle": "Track expenses, income, and budgets.",
-    "dummyDataSyncBlocked": "Dummy data sync and restore are disabled. Turn off dummy data in Settings to use Google Sheets."
+    "dummyDataSyncBlocked": "Dummy data sync and restore are disabled. Turn off dummy data in Settings to use Google Sheets.",
+    "syncTimedOut": "Sync timed out — please check your connection and try again."
   },
   "common": {
     "actions": "Actions",

--- a/test/lib/withTimeout.test.ts
+++ b/test/lib/withTimeout.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "bun:test";
+import { withTimeout, TimeoutError } from "@/lib/platform/withTimeout";
+
+test("resolves when promise completes within timeout", async () => {
+  const result = await withTimeout(Promise.resolve(42), 1000);
+  expect(result).toBe(42);
+});
+
+test("rejects with TimeoutError when promise exceeds timeout", async () => {
+  const slow = new Promise<number>((resolve) => setTimeout(() => resolve(42), 500));
+  try {
+    await withTimeout(slow, 10);
+    expect(true).toBe(false); // should not reach
+  } catch (err) {
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect((err as TimeoutError).message).toContain("timed out");
+  }
+});
+
+test("TimeoutError has the correct name", () => {
+  const err = new TimeoutError("test");
+  expect(err.name).toBe("TimeoutError");
+  expect(err instanceof Error).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Added `withTimeout` utility with `TimeoutError` class in `src/lib/platform/withTimeout.ts`
- Drive API calls timeout after 30s via `driveRequest` wrapper
- Sync push/pull operations timeout after 60s per operation
- User sees "Sync timed out" message instead of infinite loading

Closes #75

## Test plan
- [x] `withTimeout` resolves when promise completes within timeout
- [x] `withTimeout` rejects with `TimeoutError` when promise exceeds timeout
- [x] `TimeoutError` has correct name and is an instance of Error
- [x] Existing Google Drive and sync tests still pass
- [x] Full test suite passes (593 pass, 0 fail)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)