### PR TITLE
test: add error recovery tests for Google Drive API

### DIFF
--- a/test/lib/googleDrive.test.ts
+++ b/test/lib/googleDrive.test.ts
@@ -5,7 +5,9 @@ import {
   findOrthoFolder,
   isSpreadsheetActive,
   listSheetsInFolder,
+  findOrCreateOrthoSheet,
 } from "@/lib/google/googleDrive";
+import { TimeoutError } from "@/lib/platform/withTimeout";
 
 const originalFetch = globalThis.fetch;
 
@@ -98,6 +100,73 @@ test("createOrthoFolder throws on API failure", async () => {
   await expect(createOrthoFolder("token")).rejects.toThrow("Drive API failed: 403");
 });
 
+test("findOrthoFolder returns null when no folders match", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response(JSON.stringify({ files: [] }), {
+      status: 200,
+    }) as unknown as Response;
+  }) as typeof fetch;
+
+  const folder = await findOrthoFolder("token");
+  expect(folder).toBeNull();
+});
+
+test("findOrthoFolder throws on 403 permission error", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response("forbidden", { status: 403 }) as unknown as Response;
+  }) as typeof fetch;
+
+  await expect(findOrthoFolder("token")).rejects.toThrow("Drive API failed: 403");
+});
+
+test("findOrthoFolder throws on 404", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response("not found", { status: 404 }) as unknown as Response;
+  }) as typeof fetch;
+
+  await expect(findOrthoFolder("token")).rejects.toThrow("Drive API failed: 404");
+});
+
+test("listSheetsInFolder throws on 403", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response("forbidden", { status: 403 }) as unknown as Response;
+  }) as typeof fetch;
+
+  await expect(listSheetsInFolder("token", "folder-1")).rejects.toThrow(
+    "Drive API failed: 403",
+  );
+});
+
+test("listSheetsInFolder returns empty array when no sheets exist", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response(JSON.stringify({ files: [] }), {
+      status: 200,
+    }) as unknown as Response;
+  }) as typeof fetch;
+
+  const sheets = await listSheetsInFolder("token", "folder-1");
+  expect(sheets).toEqual([]);
+});
+
+test("createSheetInFolder throws on Sheets API failure", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response("internal error", { status: 500 }) as unknown as Response;
+  }) as typeof fetch;
+
+  await expect(
+    createSheetInFolder("token", "folder-1", "Test Sheet"),
+  ).rejects.toThrow("Sheets API failed: 500");
+});
+
+test("isSpreadsheetActive returns false on network error", async () => {
+  globalThis.fetch = mock(async () => {
+    throw new Error("Network error");
+  }) as typeof fetch;
+
+  const active = await isSpreadsheetActive("token", "sheet-1");
+  expect(active).toBe(false);
+});
+
 test("isSpreadsheetActive returns false when file is trashed", async () => {
   globalThis.fetch = mock(async () => {
     return new Response(
@@ -111,5 +180,37 @@ test("isSpreadsheetActive returns false when file is trashed", async () => {
   }) as typeof fetch;
 
   const active = await isSpreadsheetActive("token", "sheet-1");
+  expect(active).toBe(false);
+});
+
+test("isSpreadsheetActive returns true for active spreadsheet", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response(
+      JSON.stringify({
+        id: "sheet-1",
+        mimeType: "application/vnd.google-apps.spreadsheet",
+        trashed: false,
+      }),
+      { status: 200 },
+    ) as unknown as Response;
+  }) as typeof fetch;
+
+  const active = await isSpreadsheetActive("token", "sheet-1");
+  expect(active).toBe(true);
+});
+
+test("isSpreadsheetActive returns false for non-spreadsheet mime type", async () => {
+  globalThis.fetch = mock(async () => {
+    return new Response(
+      JSON.stringify({
+        id: "doc-1",
+        mimeType: "application/vnd.google-apps.document",
+        trashed: false,
+      }),
+      { status: 200 },
+    ) as unknown as Response;
+  }) as typeof fetch;
+
+  const active = await isSpreadsheetActive("token", "doc-1");
   expect(active).toBe(false);
 });


### PR DESCRIPTION
## Summary
- Added 9 new error and edge case tests for Google Drive API operations
- Covers 403/404 permission errors, empty results, network errors, and mime type validation
- Total Drive API tests: 15 (was 6)

Closes #76

## Test plan
- [x] `findOrthoFolder` returns null for empty results
- [x] `findOrthoFolder` throws on 403 and 404 errors
- [x] `listSheetsInFolder` throws on 403 and returns empty array
- [x] `createSheetInFolder` throws on Sheets API 500
- [x] `isSpreadsheetActive` returns false on network error
- [x] `isSpreadsheetActive` returns true for active spreadsheet, false for wrong mime type
- [x] Full test suite passes (602 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)