### PR TITLE
feat: validate localStorage data on load to prevent corruption

### DIFF
--- a/src/context/BudgetContext.tsx
+++ b/src/context/BudgetContext.tsx
@@ -82,7 +82,7 @@ interface StoredBudgetRaw {
   owners: string[];
 }
 
-function loadStoredBudget(): StoredBudgetRaw {
+export function loadStoredBudget(): StoredBudgetRaw {
   try {
     const raw = storage.getItem(STORAGE_KEYS.BUDGET_DATA);
     if (raw) {
@@ -110,22 +110,46 @@ function loadStoredBudget(): StoredBudgetRaw {
             return filtered;
           })()
         : [...ALL_EXPENSE_SOURCES];
+      const isoDateRe = /^\d{4}-\d{2}-\d{2}$/;
+      const isValidRecord = (r: { amount?: unknown; date?: unknown }) =>
+        Number.isFinite(r.amount) &&
+        typeof r.date === "string" &&
+        isoDateRe.test(r.date);
+
+      const rawExpenses = Array.isArray(data.expenses)
+        ? data.expenses.map((e) => ({
+            ...e,
+            owner:
+              (e as Expense & { cardMember?: string }).owner ??
+              (e as Expense & { cardMember?: string }).cardMember ??
+              undefined,
+            paidByOwner:
+              e.paidByOwner ??
+              (e as Expense & { cardMember?: string }).owner ??
+              (e as Expense & { cardMember?: string }).cardMember ??
+              undefined,
+          }))
+        : [];
+      const validExpenses = rawExpenses.filter((e) => {
+        if (!isValidRecord(e)) {
+          console.warn("[budget] Skipping invalid expense from storage:", e.id);
+          return false;
+        }
+        return true;
+      });
+
+      const rawIncome = Array.isArray(data.income) ? data.income : [];
+      const validIncome = rawIncome.filter((i) => {
+        if (!isValidRecord(i)) {
+          console.warn("[budget] Skipping invalid income from storage:", i.id);
+          return false;
+        }
+        return true;
+      });
+
       return {
-        expenses: Array.isArray(data.expenses)
-          ? data.expenses.map((e) => ({
-              ...e,
-              owner:
-                (e as Expense & { cardMember?: string }).owner ??
-                (e as Expense & { cardMember?: string }).cardMember ??
-                undefined,
-              paidByOwner:
-                e.paidByOwner ??
-                (e as Expense & { cardMember?: string }).owner ??
-                (e as Expense & { cardMember?: string }).cardMember ??
-                undefined,
-            }))
-          : [],
-        income: Array.isArray(data.income) ? data.income : [],
+        expenses: validExpenses,
+        income: validIncome,
         debts: Array.isArray(data.debts) ? data.debts : [],
         debtPayments: Array.isArray(data.debtPayments)
           ? data.debtPayments

--- a/test/lib/loadStoredBudget.test.ts
+++ b/test/lib/loadStoredBudget.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, test, expect } from "bun:test";
+import { storage, STORAGE_KEYS } from "@/lib/platform/storage";
+import { loadStoredBudget } from "@/context/BudgetContext";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test("filters out expenses with NaN amount", () => {
+  storage.setItem(
+    STORAGE_KEYS.BUDGET_DATA,
+    JSON.stringify({
+      expenses: [
+        { id: "1", date: "2026-01-15", amount: 50, description: "Valid", category: "Food", source: "manual" },
+        { id: "2", date: "2026-01-16", amount: NaN, description: "Bad", category: "Food", source: "manual" },
+      ],
+      income: [],
+    }),
+  );
+  const data = loadStoredBudget();
+  expect(data.expenses.length).toBe(1);
+  expect(data.expenses[0]!.id).toBe("1");
+});
+
+test("filters out expenses with invalid date", () => {
+  storage.setItem(
+    STORAGE_KEYS.BUDGET_DATA,
+    JSON.stringify({
+      expenses: [
+        { id: "1", date: "2026-01-15", amount: 50, description: "Valid", category: "Food", source: "manual" },
+        { id: "2", date: "not-a-date", amount: 30, description: "Bad date", category: "Food", source: "manual" },
+      ],
+      income: [],
+    }),
+  );
+  const data = loadStoredBudget();
+  expect(data.expenses.length).toBe(1);
+  expect(data.expenses[0]!.id).toBe("1");
+});
+
+test("filters out income with non-finite amount", () => {
+  storage.setItem(
+    STORAGE_KEYS.BUDGET_DATA,
+    JSON.stringify({
+      expenses: [],
+      income: [
+        { id: "1", date: "2026-01-15", amount: 1000, description: "Salary", category: "Job" },
+        { id: "2", date: "2026-01-16", amount: Infinity, description: "Bad", category: "Job" },
+      ],
+    }),
+  );
+  const data = loadStoredBudget();
+  expect(data.income.length).toBe(1);
+  expect(data.income[0]!.id).toBe("1");
+});
+
+test("keeps valid data when all records pass validation", () => {
+  storage.setItem(
+    STORAGE_KEYS.BUDGET_DATA,
+    JSON.stringify({
+      expenses: [
+        { id: "1", date: "2026-01-15", amount: 50, description: "Coffee", category: "Food", source: "manual" },
+      ],
+      income: [
+        { id: "1", date: "2026-01-15", amount: 1000, description: "Salary", category: "Job" },
+      ],
+    }),
+  );
+  const data = loadStoredBudget();
+  expect(data.expenses.length).toBe(1);
+  expect(data.income.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- Expenses and income records loaded from localStorage are now validated
- Records with non-finite amounts or invalid dates (not YYYY-MM-DD) are filtered out
- Console warnings logged for skipped records to aid debugging
- Exported `loadStoredBudget()` for testability

Closes #79

## Test plan
- [x] Expenses with NaN amount are filtered out
- [x] Expenses with invalid date format are filtered out
- [x] Income with Infinity amount are filtered out
- [x] Valid records pass through unchanged
- [x] Full test suite passes (618 pass, 0 fail)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)