### PR TITLE
feat: language picker popover redesign

### DIFF
--- a/src/components/ds/DsLanguagePicker.tsx
+++ b/src/components/ds/DsLanguagePicker.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Globe, Check } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { LANGUAGE_OPTIONS } from "@/components/layout/layoutConstants";
+
+interface DsLanguagePickerProps {
+  value: string;
+  onChange: (locale: string) => void;
+  /** Compact mode: icon-only trigger (used when sidebar is collapsed) */
+  compact?: boolean;
+  className?: string;
+}
+
+export function DsLanguagePicker({
+  value,
+  onChange,
+  compact,
+  className,
+}: DsLanguagePickerProps) {
+  const [open, setOpen] = useState(false);
+  const currentLabel =
+    LANGUAGE_OPTIONS.find((o) => o.value === value)?.label ?? value;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex items-center gap-2 rounded-[var(--radius-control)] transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[var(--focus-ring)]/45",
+            compact
+              ? "justify-center size-10 text-[var(--text-secondary)] hover:bg-[var(--control-hover)] hover:text-[var(--text-primary)]"
+              : "w-full border border-[var(--control-border)] bg-[var(--control-surface)] px-3 h-11 min-h-[44px] text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--control-hover)] hover:border-[var(--border-strong)]",
+            className,
+          )}
+        >
+          <Globe className={compact ? "size-4" : "size-3.5 shrink-0 text-[var(--text-secondary)]"} />
+          {!compact && (
+            <span className="flex-1 text-left truncate">{currentLabel}</span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side={compact ? "right" : "top"}
+        align={compact ? "end" : "start"}
+        className="w-48 p-1"
+      >
+        <div className="flex flex-col">
+          {LANGUAGE_OPTIONS.map((option) => {
+            const isActive = value === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                className={cn(
+                  "flex items-center justify-between gap-2 rounded-[calc(var(--radius-control)-4px)] px-2.5 py-2 text-sm transition-colors select-none",
+                  isActive
+                    ? "bg-[var(--interactive-primary)] text-[var(--interactive-primary-foreground)] font-medium"
+                    : "text-[var(--text-primary)] hover:bg-[var(--control-hover)]",
+                )}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+              >
+                <span>{option.label}</span>
+                {isActive && <Check className="size-3.5 shrink-0" />}
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ds/index.ts
+++ b/src/components/ds/index.ts
@@ -13,6 +13,7 @@ export { DsActionBar } from "./DsActionBar";
 export { DsWidgetCard } from "./DsWidgetCard";
 export { DsWidgetShell } from "./DsWidgetShell";
 export { DsWidgetCatalog } from "./DsWidgetCatalog";
+export { DsLanguagePicker } from "./DsLanguagePicker";
 export { DsSidebarBrand } from "./DsSidebarBrand";
 export { DsSidebarNavItem } from "./DsSidebarNavItem";
 export {

--- a/src/components/layout/MobileBottomNav.tsx
+++ b/src/components/layout/MobileBottomNav.tsx
@@ -4,18 +4,11 @@ import { useTranslation } from "react-i18next";
 import {
   LogIn,
   LogOut,
-  Globe,
   MoreHorizontal,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { DsLanguagePicker } from "@/components/ds";
 import {
   Dialog,
   DialogContent,
@@ -23,7 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Avatar } from "./Avatar";
-import { bottomNavItems, moreNavItems, LANGUAGE_OPTIONS } from "./layoutConstants";
+import { bottomNavItems, moreNavItems } from "./layoutConstants";
 
 interface MobileBottomNavProps {
   isActivePath: (to: string) => boolean;
@@ -113,19 +106,7 @@ export function MobileBottomNav({
               <div className="px-2 text-xs font-medium text-muted-foreground">
                 {t("layout.language")}
               </div>
-              <Select value={currentLng} onValueChange={handleLanguageChange}>
-                <SelectTrigger className="h-9 w-full">
-                  <Globe className="size-4 shrink-0" />
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="max-h-[280px]!">
-                  {LANGUAGE_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <DsLanguagePicker value={currentLng} onChange={handleLanguageChange} />
             </div>
             <div className="pt-2">
               {isSignedIn ? (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,19 +3,12 @@ import type { Location } from "react-router-dom";
 import {
   LogIn,
   LogOut,
-  Globe,
   ChevronDown,
   PanelLeftClose,
   PanelLeftOpen,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { DsLanguagePicker } from "@/components/ds";
 import {
   Popover,
   PopoverContent,
@@ -29,11 +22,10 @@ import {
 import {
   DsSidebarBrand,
   DsSidebarNavItem,
-  DS_SIDEBAR_LANGUAGE_TRIGGER_CLASS,
 } from "@/components/ds";
 import { cn } from "@/lib/utils";
 import { Avatar } from "./Avatar";
-import { LANGUAGE_OPTIONS, navGroups } from "./layoutConstants";
+import { navGroups } from "./layoutConstants";
 
 interface SidebarContentProps {
   location: Location;
@@ -108,34 +100,11 @@ export function SidebarContent({
         {/* Language */}
         {collapsed ? (
           <div className="flex justify-center">
-            <Select value={currentLng} onValueChange={handleLanguageChange}>
-              <SelectTrigger className="size-10 justify-center rounded-[var(--radius-control)] border-0 bg-transparent px-0 text-[var(--text-secondary)] hover:bg-[var(--control-hover)] hover:text-[var(--text-primary)] [&>svg:last-child]:hidden">
-                <Globe className="size-4" />
-              </SelectTrigger>
-              <SelectContent side="right" align="end" className="max-h-[280px]!">
-                {LANGUAGE_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DsLanguagePicker value={currentLng} onChange={handleLanguageChange} compact />
           </div>
         ) : (
           <div className="px-1">
-            <Select value={currentLng} onValueChange={handleLanguageChange}>
-              <SelectTrigger className={DS_SIDEBAR_LANGUAGE_TRIGGER_CLASS}>
-                <Globe className="size-3.5" />
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className="max-h-[280px]!">
-                {LANGUAGE_OPTIONS.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <DsLanguagePicker value={currentLng} onChange={handleLanguageChange} />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Replace the `Select` dropdown language picker with a new `DsLanguagePicker` component using a `Popover`
- Active language highlighted with brand color + check icon
- Supports `compact` prop for collapsed sidebar (globe icon only, popover opens to the right)
- Used in both desktop sidebar and mobile bottom nav

## Test plan
- [x] All 618 tests pass
- [x] Build succeeds
- [ ] Visual: expanded sidebar shows globe + language name trigger
- [ ] Visual: collapsed sidebar shows globe icon, popover opens right
- [ ] Visual: mobile "More" sheet shows language picker
- [ ] Selecting a language updates the UI and closes the popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)