### PR TITLE
feat: rebuild dashboard with category, heatmap, and owner widgets

### DIFF
--- a/.claude/plans/026-dashboard-rebuild.md
+++ b/.claude/plans/026-dashboard-rebuild.md
@@ -1,0 +1,89 @@
+## Plan: Category-Focused Dashboard Widgets
+
+**What:** Three new category-focused widgets for the dashboard: Spend by Category, Category Trends, and Top 5 Categories.
+**Why:** The new hierarchical category system (Food > Groceries, etc.) provides rich data that isn't surfaced on the dashboard yet.
+
+### Existing Infrastructure
+
+- `categorySlices` already computed in `useDashboardData.ts` via `buildCategoryBreakdown()` — returns `{ label, value }[]` for current month
+- Category registry (`src/lib/categories/registry.ts`) provides icons, colors, parent/sub hierarchy
+- Widget pattern: component in `widgets/`, registered in `widgetRegistry.tsx`, data piped from `useDashboardData`
+- DS components: `DsChartCard`, `DsLegendList`, `DsDataRow`, `DsEmptyState`
+- Recharts: `BarChart`, `PieChart`, `LineChart` all available
+
+### Acceptance Criteria
+
+**Widget 1: Spend by Category (bar chart)**
+- [ ] Horizontal bar chart showing spend per category, sorted by amount descending
+- [ ] Uses parent-level grouping (e.g., "Food" aggregates Groceries + Dining Out + Coffee)
+- [ ] Shows category icon and color from registry
+- [ ] Empty state when no expenses exist
+- [ ] Registered in widget registry
+
+**Widget 2: Category Trends (line chart)**
+- [ ] Line chart showing spend per parent category across months (uses dashboard range: current/6/12)
+- [ ] New selector `buildCategoryTrends()` in `dashboardSelectors.ts` that returns per-category monthly totals
+- [ ] Each line colored by the category's registry color
+- [ ] Legend showing category names
+- [ ] Empty state when insufficient data
+
+**Widget 3: Top 5 Categories (ranked list)**
+- [ ] Ranked list of the 5 highest-spend categories for the selected period
+- [ ] Shows rank number, category icon, name, amount, and percentage of total
+- [ ] Progress bar showing relative spend
+- [ ] Uses existing `categorySlices` data (no new selector needed)
+- [ ] Empty state when no expenses exist
+
+**Integration:**
+- [ ] All three widgets added to `DashboardFixedLayout.tsx` below the KPI row
+- [ ] Tests for each widget component
+- [ ] Tests for any new selector functions
+
+### Implementation Steps (TDD)
+
+Each step follows red-green-refactor: write failing test → implement → verify green → refactor.
+
+1. **`buildParentCategoryBreakdown()` selector**
+   - Write tests: groups subcategories by parent, sorts descending, handles empty/uncategorized
+   - Run tests — confirm red
+   - Implement in `dashboardSelectors.ts`
+   - Run tests — confirm green
+
+2. **`buildCategoryTrends()` selector**
+   - Write tests: returns per-parent-category monthly totals across a range of months, respects expense scope, handles empty data
+   - Run tests — confirm red
+   - Implement in `dashboardSelectors.ts`
+   - Run tests — confirm green
+
+3. **Wire new selectors into `useDashboardData.ts`**
+   - No dedicated test — verified by widget component tests in steps 4–6
+
+4. **`SpendByCategoryChart` widget**
+   - Write tests: renders bars for each parent category, shows empty state when no data, displays category names
+   - Run tests — confirm red
+   - Implement component
+   - Run tests — confirm green
+
+5. **`CategoryTrendsChart` widget**
+   - Write tests: renders lines per category, shows empty state, displays legend
+   - Run tests — confirm red
+   - Implement component
+   - Run tests — confirm green
+
+6. **`TopCategories` widget**
+   - Write tests: renders top 5 ranked items with name/amount/percentage, shows empty state, caps at 5 even with more data
+   - Run tests — confirm red
+   - Implement component
+   - Run tests — confirm green
+
+7. **Register widgets in `widgetRegistry.tsx`**
+
+8. **Add widgets to `DashboardFixedLayout.tsx`**
+   - Update existing Dashboard test to verify new widgets render
+
+### Gotchas
+
+- `categorySlices` uses composite keys like "Food > Groceries" — need to parse and group by parent for the bar chart
+- Category Trends needs multi-month data; current `buildCategoryBreakdown` only does single month — need a new selector that iterates over `monthKeys`
+- Category colors in registry are Tailwind classes (`bg-green-500`), but Recharts needs CSS color values — may need a mapping or use `getCategoryColorClass` with a lookup
+- The dashboard `range` setting controls how many months to show — Category Trends must respect this

--- a/src/lib/widgets/widget.ts
+++ b/src/lib/widgets/widget.ts
@@ -13,7 +13,11 @@ export type WidgetType =
   | "spend-by-source"
   | "owner-transfers"
   | "recent-activity"
-  | "owner-expense-by-owner";
+  | "owner-expense-by-owner"
+  | "spend-by-category"
+  | "category-trends"
+  | "top-categories"
+  | "daily-spending-heatmap";
 
 export type WidgetSize = "sm" | "md" | "lg";
 

--- a/src/lib/widgets/widgetGroups.ts
+++ b/src/lib/widgets/widgetGroups.ts
@@ -15,7 +15,7 @@ export const WIDGET_GROUPS: WidgetGroup[] = [
   {
     key: "charts",
     label: "widget.groupCharts",
-    widgets: ["cash-flow-chart", "net-trend-chart", "category-chart", "owner-split-chart", "owner-expense-by-owner"],
+    widgets: ["cash-flow-chart", "net-trend-chart", "category-chart", "owner-split-chart", "owner-expense-by-owner", "spend-by-category", "category-trends", "top-categories", "daily-spending-heatmap"],
   },
   {
     key: "lists",

--- a/src/lib/widgets/widgetRegistry.tsx
+++ b/src/lib/widgets/widgetRegistry.tsx
@@ -12,6 +12,8 @@ import {
   ArrowLeftRight,
   Clock,
   Receipt,
+  ListOrdered,
+  CalendarDays,
 } from "lucide-react";
 import { NetCashFlow } from "@/pages/dashboard/widgets/NetCashFlow";
 import { TotalSpent } from "@/pages/dashboard/widgets/TotalSpent";
@@ -26,6 +28,10 @@ import { NetTrendChart } from "@/pages/dashboard/widgets/NetTrendChart";
 import { CategoryChart } from "@/pages/dashboard/widgets/CategoryChart";
 import { OwnerSplitChart } from "@/pages/dashboard/widgets/OwnerSplitChart";
 import { OwnerExpenseByOwner } from "@/pages/dashboard/widgets/OwnerExpenseByOwner";
+import { SpendByCategoryChart } from "@/pages/dashboard/widgets/SpendByCategoryChart";
+import { CategoryTrendsChart } from "@/pages/dashboard/widgets/CategoryTrendsChart";
+import { TopCategories } from "@/pages/dashboard/widgets/TopCategories";
+import { DailySpendingHeatmap } from "@/pages/dashboard/widgets/DailySpendingHeatmap";
 import type { WidgetType, WidgetSize, WidgetRegistryEntry } from "@/lib/widgets/widget";
 import { createWidget } from "@/lib/widgets/createWidget";
 
@@ -196,6 +202,52 @@ export const WIDGET_REGISTRY: Record<WidgetType, WidgetRegistryEntry> = {
     icon: <Clock className="size-4" />,
     render: (props: AnyProps, size: WidgetSize) => (
       <RecentActivity recentActivity={props.recentActivity} size={size} />
+    ),
+  }),
+  "spend-by-category": createWidget({
+    type: "spend-by-category",
+    label: "widget.spendByCategory",
+    icon: <BarChart3 className="size-4" />,
+    defaultSize: "lg",
+    sm: { w: 6, h: 3 },
+    md: { w: 6, h: 6 },
+    lg: { w: 6, h: 6 },
+    render: (props: AnyProps, size: WidgetSize) => (
+      <SpendByCategoryChart parentCategorySlices={props.parentCategorySlices} size={size} />
+    ),
+  }),
+  "category-trends": createWidget({
+    ...CHART_WIDE_DIMS,
+    type: "category-trends",
+    label: "widget.categoryTrends",
+    icon: <Activity className="size-4" />,
+    defaultSize: "lg",
+    render: (props: AnyProps, size: WidgetSize) => (
+      <CategoryTrendsChart categoryTrends={props.categoryTrends} size={size} />
+    ),
+  }),
+  "top-categories": createWidget({
+    type: "top-categories",
+    label: "widget.topCategories",
+    icon: <ListOrdered className="size-4" />,
+    defaultSize: "lg",
+    sm: { w: 6, h: 3 },
+    md: { w: 6, h: 6 },
+    lg: { w: 6, h: 6 },
+    render: (props: AnyProps, size: WidgetSize) => (
+      <TopCategories categorySlices={props.categorySlices} size={size} />
+    ),
+  }),
+  "daily-spending-heatmap": createWidget({
+    type: "daily-spending-heatmap",
+    label: "widget.dailySpendingHeatmap",
+    icon: <CalendarDays className="size-4" />,
+    defaultSize: "lg",
+    sm: { w: 6, h: 3 },
+    md: { w: 6, h: 6 },
+    lg: { w: 6, h: 6 },
+    render: (props: AnyProps, size: WidgetSize) => (
+      <DailySpendingHeatmap dailySpending={props.dailySpending} size={size} />
     ),
   }),
 };

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -33,7 +33,7 @@ export function Dashboard() {
 
   return (
     <div data-tour-page="dashboard" className="flex flex-col min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden pb-24 md:pb-0">
-      <div className={`min-w-0 px-2 md:px-0 pt-4 md:pt-0 space-y-4${isEmpty ? " flex flex-1 flex-col" : ""}`}>
+      <div className={`min-w-0 px-4 md:px-0 pt-4 md:pt-0 space-y-4${isEmpty ? " flex flex-1 flex-col" : ""}`}>
         <div className="space-y-3" data-tour="dashboard-header">
           <DsSectionHeader
             title={

--- a/src/pages/dashboard/DashboardFixedLayout.tsx
+++ b/src/pages/dashboard/DashboardFixedLayout.tsx
@@ -1,17 +1,11 @@
-import { useTranslation } from "react-i18next";
-import { formatCurrency } from "@/lib/format";
 import { NetCashFlow } from "./widgets/NetCashFlow";
 import { TotalSpent } from "./widgets/TotalSpent";
 import { TotalIncome } from "./widgets/TotalIncome";
 import { TotalDebt } from "./widgets/TotalDebt";
 import { CashFlowChart } from "./widgets/CashFlowChart";
-import { NetTrendChart } from "./widgets/NetTrendChart";
-import { CategoryChart } from "./widgets/CategoryChart";
-import { OwnerSplitChart } from "./widgets/OwnerSplitChart";
-import { DebtSnapshot } from "./widgets/DebtSnapshot";
-import { SpendBySource } from "./widgets/SpendBySource";
-import { RecentActivity } from "./widgets/RecentActivity";
-import { OwnerTransfers } from "./widgets/OwnerTransfers";
+import { SpendByCategoryChart } from "./widgets/SpendByCategoryChart";
+import { CategoryTrendsChart } from "./widgets/CategoryTrendsChart";
+import { DailySpendingHeatmap } from "./widgets/DailySpendingHeatmap";
 import { OwnerExpenseByOwner } from "./widgets/OwnerExpenseByOwner";
 import type { useDashboardData } from "./useDashboardData";
 
@@ -25,39 +19,9 @@ function SectionDivider() {
   return <hr className="border-border/40" />;
 }
 
-function MonthInReview({ data }: { data: DashboardData }) {
-  const { t } = useTranslation();
-  const { kpis } = data;
-  const net = kpis.netCashFlow;
-
-  const [year, month] = data.selectedMonthKey.split("-");
-  const monthDate = new Date(Number(year), Number(month) - 1);
-  const monthName = monthDate.toLocaleString("default", { month: "long", year: "numeric" });
-
-  return (
-    <div className="mt-4 rounded-lg border border-border/40 bg-muted/30 px-5 py-4 space-y-1.5">
-      <h2 className="text-base font-semibold tracking-tight md:text-lg">{monthName}</h2>
-      <p className="text-sm leading-relaxed text-muted-foreground">
-        {net >= 0
-          ? t("dashboard.summaryPositive", {
-              defaultValue: `You earned ${formatCurrency(kpis.totalIncome)} and spent ${formatCurrency(kpis.totalSpent)}, leaving ${formatCurrency(net)} in positive cash flow.`,
-            })
-          : t("dashboard.summaryNegative", {
-              defaultValue: `You earned ${formatCurrency(kpis.totalIncome)} and spent ${formatCurrency(kpis.totalSpent)}. Spending exceeded income by ${formatCurrency(Math.abs(net))}.`,
-            })}
-        {kpis.debtOutstanding > 0 &&
-          ` ${t("dashboard.summaryDebt", { defaultValue: `${formatCurrency(kpis.debtOutstanding)} in debt remains outstanding.` })}`}
-      </p>
-    </div>
-  );
-}
-
 export function DashboardFixedLayout({ data }: DashboardFixedLayoutProps) {
   return (
-    <div className="space-y-12">
-      {/* Month in Review — narrative summary */}
-      <MonthInReview data={data} />
-
+    <div className="space-y-12 pb-24">
       {/* KPI Row — flat metrics, no cards */}
       <div className="grid grid-cols-2 gap-x-6 gap-y-4 md:grid-cols-4">
         <NetCashFlow
@@ -89,7 +53,7 @@ export function DashboardFixedLayout({ data }: DashboardFixedLayoutProps) {
       <SectionDivider />
 
       {/* Cash Flow Chart — full width */}
-      <section className="space-y-4">
+      <section>
         <CashFlowChart
           cashFlowDisplayRows={data.cashFlowDisplayRows}
           incomeOwnerKeys={data.incomeOwnerKeys}
@@ -100,79 +64,42 @@ export function DashboardFixedLayout({ data }: DashboardFixedLayoutProps) {
 
       <SectionDivider />
 
-      {/* Net Trend + Category Breakdown */}
-      <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
-        <section className="space-y-4">
-          <NetTrendChart
-            netCashFlowRows={data.netCashFlowRows}
-            range={data.range}
-            size="lg"
-          />
-        </section>
-        <section className="space-y-4">
-          <CategoryChart
-            categorySlices={data.categorySlices}
-            size="lg"
-          />
-        </section>
-      </div>
-
-      <SectionDivider />
-
-      {/* Owner Split + Spend by Source */}
-      <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
-        <section className="space-y-4">
-          <OwnerSplitChart
-            ownerSlices={data.ownerSlices}
-            size="lg"
-          />
-        </section>
-        <section className="space-y-4">
-          <SpendBySource
-            spendBySourceRows={data.spendBySourceRows}
-            size="lg"
-          />
-        </section>
-      </div>
-
-      <SectionDivider />
-
-      {/* Debt Snapshot + Recent Activity */}
-      <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
-        <section className="space-y-4">
-          <DebtSnapshot
-            debtRows={data.debtRows}
-            size="lg"
-          />
-        </section>
-        <section className="space-y-4">
-          <RecentActivity
-            recentActivity={data.recentActivity}
-            size="lg"
-          />
-        </section>
-      </div>
-
-      <SectionDivider />
-
-      {/* Owner Expense Breakdown — full width */}
-      <section className="space-y-4">
-        <OwnerExpenseByOwner
-          visibleOwnerNetRows={data.visibleOwnerNetRows}
-          ownerExpenseItemsByOwner={data.ownerExpenseItemsByOwner}
-          totalSpentForSelectedRange={data.totalSpentForSelectedRange}
-          percentFormatter={data.percentFormatter}
+      {/* Daily Spending Heatmap — full width */}
+      <section>
+        <DailySpendingHeatmap
+          dailySpending={data.dailySpending}
           size="lg"
         />
       </section>
 
       <SectionDivider />
 
-      {/* Owner Transfers — full width */}
-      <section className="space-y-4">
-        <OwnerTransfers
-          ownerTransfersMtd={data.ownerTransfersMtd}
-          ownerTransfersMtdTotal={data.ownerTransfersMtdTotal}
+      {/* Spend by Category + Category Trends — side by side */}
+      <div className="grid grid-cols-1 items-start gap-6 md:grid-cols-2">
+        <section>
+          <SpendByCategoryChart
+            parentCategorySlices={data.parentCategorySlices}
+            size="lg"
+          />
+        </section>
+        <section>
+          <CategoryTrendsChart
+            categoryTrends={data.categoryTrends}
+            categoryComparison={data.categoryComparison}
+            size="lg"
+          />
+        </section>
+      </div>
+
+      <SectionDivider />
+
+      {/* Expense by Owner — full width */}
+      <section>
+        <OwnerExpenseByOwner
+          visibleOwnerNetRows={data.visibleOwnerNetRows}
+          ownerExpenseItemsByOwner={data.ownerExpenseItemsByOwner}
+          totalSpentForSelectedRange={data.totalSpentForSelectedRange}
+          percentFormatter={data.percentFormatter}
           size="lg"
         />
       </section>

--- a/src/pages/dashboard/dashboardSelectors.ts
+++ b/src/pages/dashboard/dashboardSelectors.ts
@@ -14,15 +14,20 @@ import {
 } from "@/lib/math";
 import { isMortgageCategory } from "@/lib/domain/mortgageCategory";
 import type { Debt, DebtPayment, Expense, Income, OwnerTransfer } from "@/types/core";
+import { COMPOSITE_KEY_SEPARATOR } from "@/lib/categories/registry";
 import type {
   DashboardCashFlowRow,
   DashboardCategorySlice,
+  DashboardCategoryComparisonRow,
+  DashboardCategoryTrends,
+  DashboardDailySpending,
   DashboardDebtRow,
   DashboardExpenseScope,
   DashboardKpis,
   DashboardOwnerNetRow,
   DashboardOwnerSlice,
   DashboardOwnerExpenseItem,
+  DashboardParentCategorySlice,
   DashboardRange,
   DashboardRecentItem,
 } from "@/types/dashboard";
@@ -184,17 +189,22 @@ export function buildCashFlowRows({
 export function buildCategoryBreakdown({
   expenses,
   currentMonthKey,
+  monthKeys,
   scope,
   uncategorizedLabel = "Uncategorized",
 }: {
   expenses: Expense[];
-  currentMonthKey: string;
+  currentMonthKey?: string;
+  monthKeys?: string[];
   scope: DashboardExpenseScope;
   uncategorizedLabel?: string;
 }): DashboardCategorySlice[] {
+  const allowedMonths = monthKeys ? new Set(monthKeys) : null;
   const byCategory = new Map<string, number>();
   for (const expense of expenses) {
-    if (!isValidDate(expense.date) || monthFromDate(expense.date) !== currentMonthKey) continue;
+    if (!isValidDate(expense.date)) continue;
+    const mk = monthFromDate(expense.date);
+    if (allowedMonths ? !allowedMonths.has(mk) : mk !== currentMonthKey) continue;
     if (!shouldIncludeExpense(expense, scope)) continue;
     const category = (expense.category || "").trim() || uncategorizedLabel;
     byCategory.set(category, (byCategory.get(category) ?? 0) + expense.amount);
@@ -463,4 +473,186 @@ export function buildOwnerNetRows({
 export function getOwnerDrilldownParam(slice: DashboardOwnerSlice): string {
   if (slice.owner) return slice.owner;
   return slice.key === SHARED_BUCKET_KEY ? "_shared" : "_none";
+}
+
+function getParentLabel(category: string, uncategorizedLabel: string): string {
+  const trimmed = (category || "").trim();
+  if (!trimmed) return uncategorizedLabel;
+  const sepIdx = trimmed.indexOf(COMPOSITE_KEY_SEPARATOR);
+  return sepIdx >= 0 ? trimmed.slice(0, sepIdx) : trimmed;
+}
+
+export function buildParentCategoryBreakdown({
+  expenses,
+  currentMonthKey,
+  monthKeys,
+  scope,
+  uncategorizedLabel = "Uncategorized",
+}: {
+  expenses: Expense[];
+  currentMonthKey?: string;
+  monthKeys?: string[];
+  scope: DashboardExpenseScope;
+  uncategorizedLabel?: string;
+}): DashboardParentCategorySlice[] {
+  const allowedMonths = monthKeys ? new Set(monthKeys) : null;
+  const byParent = new Map<string, number>();
+  for (const expense of expenses) {
+    if (!isValidDate(expense.date)) continue;
+    const mk = monthFromDate(expense.date);
+    if (allowedMonths ? !allowedMonths.has(mk) : mk !== currentMonthKey) continue;
+    if (!shouldIncludeExpense(expense, scope)) continue;
+    const parent = getParentLabel(expense.category, uncategorizedLabel);
+    byParent.set(parent, (byParent.get(parent) ?? 0) + expense.amount);
+  }
+
+  return Array.from(byParent.entries())
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+export function buildCategoryTrends({
+  expenses,
+  monthKeys,
+  scope,
+  uncategorizedLabel = "Uncategorized",
+}: {
+  expenses: Expense[];
+  monthKeys: string[];
+  scope: DashboardExpenseScope;
+  uncategorizedLabel?: string;
+}): DashboardCategoryTrends {
+  const monthKeySet = new Set(monthKeys);
+  const monthIndexMap = new Map(monthKeys.map((k, i) => [k, i]));
+
+  // category → monthIndex → total
+  const categoryMonthTotals = new Map<string, number[]>();
+  const categoryTotals = new Map<string, number>();
+
+  for (const expense of expenses) {
+    if (!isValidDate(expense.date)) continue;
+    const mk = monthFromDate(expense.date);
+    if (!monthKeySet.has(mk)) continue;
+    if (!shouldIncludeExpense(expense, scope)) continue;
+
+    const parent = getParentLabel(expense.category, uncategorizedLabel);
+    const monthIdx = monthIndexMap.get(mk)!;
+
+    if (!categoryMonthTotals.has(parent)) {
+      categoryMonthTotals.set(parent, new Array(monthKeys.length).fill(0));
+    }
+    categoryMonthTotals.get(parent)![monthIdx] += expense.amount;
+    categoryTotals.set(parent, (categoryTotals.get(parent) ?? 0) + expense.amount);
+  }
+
+  // Sort categories by total spend descending
+  const sortedCategories = Array.from(categoryTotals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([cat]) => cat);
+
+  return {
+    monthKeys,
+    categories: sortedCategories,
+    series: sortedCategories.map((category) => ({
+      category,
+      values: categoryMonthTotals.get(category)!,
+    })),
+  };
+}
+
+export function buildCategoryComparison({
+  expenses,
+  currentMonthKey,
+  scope,
+  uncategorizedLabel = "Uncategorized",
+}: {
+  expenses: Expense[];
+  currentMonthKey: string;
+  scope: DashboardExpenseScope;
+  uncategorizedLabel?: string;
+}): DashboardCategoryComparisonRow[] {
+  const previousMonthKey = getPreviousMonthKey(currentMonthKey);
+  const currentTotals = new Map<string, number>();
+  const previousTotals = new Map<string, number>();
+
+  for (const expense of expenses) {
+    if (!isValidDate(expense.date)) continue;
+    if (!shouldIncludeExpense(expense, scope)) continue;
+    const mk = monthFromDate(expense.date);
+    if (mk !== currentMonthKey && mk !== previousMonthKey) continue;
+
+    const parent = getParentLabel(expense.category, uncategorizedLabel);
+    const target = mk === currentMonthKey ? currentTotals : previousTotals;
+    target.set(parent, (target.get(parent) ?? 0) + expense.amount);
+  }
+
+  const allCategories = new Set([...currentTotals.keys(), ...previousTotals.keys()]);
+  const rows: DashboardCategoryComparisonRow[] = [];
+
+  for (const label of allCategories) {
+    const currentValue = currentTotals.get(label) ?? 0;
+    const previousValue = previousTotals.get(label) ?? 0;
+    const changePct = computeMonthOverMonthPct(currentValue, previousValue);
+
+    let direction: "up" | "down" | "flat";
+    if (changePct === null) {
+      direction = currentValue > 0 ? "up" : "flat";
+    } else if (changePct > 0) {
+      direction = "up";
+    } else if (changePct < 0) {
+      direction = "down";
+    } else {
+      direction = "flat";
+    }
+
+    rows.push({ label, currentValue, previousValue, changePct, direction });
+  }
+
+  return rows.sort((a, b) => b.currentValue - a.currentValue);
+}
+
+export function buildDailySpending({
+  expenses,
+  monthKey,
+  scope,
+}: {
+  expenses: Expense[];
+  monthKey: string;
+  scope: DashboardExpenseScope;
+}): DashboardDailySpending {
+  const [y, m] = monthKey.split("-").map(Number);
+  const daysInMonth = new Date(y!, m!, 0).getDate();
+
+  type DayBucket = { total: number; items: { id: string; description: string; category: string; amount: number }[] };
+  const dayMap = new Map<string, DayBucket>();
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = `${monthKey}-${String(d).padStart(2, "0")}`;
+    dayMap.set(date, { total: 0, items: [] });
+  }
+
+  for (const expense of expenses) {
+    if (!isValidDate(expense.date)) continue;
+    if (monthFromDate(expense.date) !== monthKey) continue;
+    if (!shouldIncludeExpense(expense, scope)) continue;
+    const bucket = dayMap.get(expense.date);
+    if (bucket) {
+      bucket.total += expense.amount;
+      bucket.items.push({
+        id: expense.id,
+        description: expense.description,
+        category: expense.category,
+        amount: expense.amount,
+      });
+    }
+  }
+
+  let maxAmount = 0;
+  const days = Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, bucket]) => {
+      if (bucket.total > maxAmount) maxAmount = bucket.total;
+      return { date, amount: bucket.total, items: bucket.items };
+    });
+
+  return { monthKey, days, maxAmount };
 }

--- a/src/pages/dashboard/useDashboardData.ts
+++ b/src/pages/dashboard/useDashboardData.ts
@@ -21,6 +21,10 @@ import {
   buildSpendBySource,
   buildOwnerTransfersMtd,
   buildRecentActivity,
+  buildParentCategoryBreakdown,
+  buildCategoryTrends,
+  buildCategoryComparison,
+  buildDailySpending,
   getCurrentMonthKey,
   getRangeMonthKeys,
 } from "@/pages/dashboard/dashboardSelectors";
@@ -156,11 +160,54 @@ export function useDashboardData() {
     () =>
       buildCategoryBreakdown({
         expenses: scopedExpenses,
+        monthKeys,
+        scope: expenseScope,
+        uncategorizedLabel: t("common.uncategorized"),
+      }),
+    [scopedExpenses, monthKeys, expenseScope, t],
+  );
+
+  const parentCategorySlices = useMemo(
+    () =>
+      buildParentCategoryBreakdown({
+        expenses: scopedExpenses,
+        monthKeys,
+        scope: expenseScope,
+        uncategorizedLabel: t("common.uncategorized"),
+      }),
+    [scopedExpenses, monthKeys, expenseScope, t],
+  );
+
+  const categoryTrends = useMemo(
+    () =>
+      buildCategoryTrends({
+        expenses: scopedExpenses,
+        monthKeys,
+        scope: expenseScope,
+        uncategorizedLabel: t("common.uncategorized"),
+      }),
+    [scopedExpenses, monthKeys, expenseScope, t],
+  );
+
+  const categoryComparison = useMemo(
+    () =>
+      buildCategoryComparison({
+        expenses: scopedExpenses,
         currentMonthKey,
         scope: expenseScope,
         uncategorizedLabel: t("common.uncategorized"),
       }),
     [scopedExpenses, currentMonthKey, expenseScope, t],
+  );
+
+  const dailySpending = useMemo(
+    () =>
+      buildDailySpending({
+        expenses: scopedExpenses,
+        monthKey: currentMonthKey,
+        scope: expenseScope,
+      }),
+    [scopedExpenses, currentMonthKey, expenseScope],
   );
 
   const ownerSlices = useMemo(
@@ -335,6 +382,10 @@ export function useDashboardData() {
     incomeOwnerKeys,
     netCashFlowRows,
     categorySlices,
+    parentCategorySlices,
+    categoryTrends,
+    categoryComparison,
+    dailySpending,
     ownerSlices,
     visibleOwnerNetRows,
     ownerExpenseItemsByOwner,

--- a/src/pages/dashboard/widgets/CashFlowChart.tsx
+++ b/src/pages/dashboard/widgets/CashFlowChart.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import {
   Bar,
   BarChart,
-  CartesianGrid,
   XAxis,
   YAxis,
 } from "recharts";
@@ -132,8 +131,8 @@ export function CashFlowChart({
 
     return (
       <DsChartCard title={chartTitle} className="min-w-0" size={effectiveSize}>
-        <div className="flex items-start gap-8">
-          <div className="w-1/2 shrink-0">
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8">
+          <div className="shrink-0 md:w-1/2">
             <ChartContainer
               config={{
                 expenses: { label: t("dashboard.chartExpenses"), color: "var(--viz-expense)" },
@@ -145,9 +144,8 @@ export function CashFlowChart({
               heightDesktop={240}
             >
               <BarChart data={cashFlowDisplayRows} barCategoryGap="30%">
-                <CartesianGrid vertical={false} />
-                <XAxis dataKey="monthAxisLabel" interval={0} tickMargin={8} minTickGap={0} />
-                <YAxis />
+                <XAxis dataKey="monthAxisLabel" interval={0} tickMargin={8} minTickGap={0} axisLine={false} tickLine={false} />
+                <YAxis hide />
                 <ChartTooltip content={tooltipContent} />
                 {incomeOwnerKeys.map((owner, index) => (
                   <Bar
@@ -166,7 +164,7 @@ export function CashFlowChart({
               </BarChart>
             </ChartContainer>
           </div>
-          <div className="flex-1 space-y-4 pt-2">
+          <div className="flex-1 space-y-4 md:pt-2">
             <div className="space-y-3">
               <div className="flex items-baseline justify-between">
                 <span className="text-sm text-muted-foreground">{t("dashboard.chartIncome")}</span>
@@ -231,9 +229,8 @@ export function CashFlowChart({
           heightDesktop={300}
         >
           <BarChart data={cashFlowDisplayRows}>
-            <CartesianGrid vertical={false} />
-            <XAxis dataKey="monthAxisLabel" interval={0} tickMargin={8} minTickGap={0} />
-            <YAxis />
+              <XAxis dataKey="monthAxisLabel" interval={0} tickMargin={8} minTickGap={0} axisLine={false} tickLine={false} />
+            <YAxis hide />
             <ChartTooltip content={tooltipContent} />
             {incomeOwnerKeys.map((owner, index) => (
               <Bar
@@ -273,7 +270,6 @@ export function CashFlowChart({
           data={cashFlowDisplayRows}
           margin={{ top: 4, right: 24, left: -4, bottom: 2 }}
         >
-          <CartesianGrid vertical={false} />
           <XAxis
             dataKey="monthAxisLabel"
             tick={{ fontSize: 11 }}
@@ -281,16 +277,10 @@ export function CashFlowChart({
             minTickGap={18}
             interval="preserveStartEnd"
             padding={{ left: 0, right: 8 }}
+            axisLine={false}
+            tickLine={false}
           />
-          <YAxis
-            tick={{ fontSize: 11 }}
-            width={34}
-            tickFormatter={(value) => {
-              const abs = Math.abs(Number(value));
-              if (abs >= 1000) return `${Math.round(Number(value) / 1000)}k`;
-              return String(Math.round(Number(value)));
-            }}
-          />
+          <YAxis hide />
           <ChartTooltip content={tooltipContent} />
           <Bar dataKey="incomeTotal" name={t("dashboard.chartIncome")} fill="var(--viz-income)" radius={[4, 4, 0, 0]} />
           <Bar

--- a/src/pages/dashboard/widgets/CategoryTrendsChart.tsx
+++ b/src/pages/dashboard/widgets/CategoryTrendsChart.tsx
@@ -1,0 +1,181 @@
+import { useTranslation } from "react-i18next";
+import { Line, LineChart, XAxis, YAxis } from "recharts";
+import { Activity } from "lucide-react";
+import { formatCurrency } from "@/lib/format";
+import { DsChartCard, DsEmptyState } from "@/components/ds";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import type { DashboardCategoryComparisonRow, DashboardCategoryTrends } from "@/types/dashboard";
+import { cn } from "@/lib/utils";
+import type { WidgetSize } from "@/lib/widgets/widget";
+
+const LINE_COLORS = [
+  "var(--viz-series-1)",
+  "var(--viz-series-2)",
+  "var(--viz-series-3)",
+  "var(--viz-series-4)",
+  "var(--viz-series-5)",
+  "var(--viz-expense)",
+  "var(--viz-debt)",
+];
+
+interface CategoryTrendsChartProps {
+  categoryTrends: DashboardCategoryTrends;
+  categoryComparison?: DashboardCategoryComparisonRow[];
+  size?: WidgetSize;
+}
+
+export function CategoryTrendsChart({
+  categoryTrends,
+  categoryComparison,
+  size = "lg",
+}: CategoryTrendsChartProps) {
+  const { t } = useTranslation();
+  const title = t("dashboard.categoryTrends", { defaultValue: "Category Trends" });
+
+  if (categoryTrends.categories.length === 0) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <DsEmptyState
+          icon={<Activity className="size-5" />}
+          title={t("dashboard.noCategoryTrends", { defaultValue: "No trend data" })}
+          className="py-4"
+        />
+      </DsChartCard>
+    );
+  }
+
+  const isSingleMonth = categoryTrends.monthKeys.length < 2;
+
+  // sm: top category trend direction
+  if (size === "sm") {
+    const top = categoryTrends.series[0];
+    if (!top || top.values.length < 2) {
+      return (
+        <DsChartCard title={title} size={size}>
+          <p className="text-sm text-muted-foreground">{top?.category ?? "—"}</p>
+        </DsChartCard>
+      );
+    }
+    const last = top.values[top.values.length - 1]!;
+    const prev = top.values[top.values.length - 2]!;
+    const direction = last >= prev ? "up" : "down";
+    return (
+      <DsChartCard title={title} size={size}>
+        <p className="text-sm font-medium">{top.category}</p>
+        <p className="text-xs text-muted-foreground">
+          {direction === "up" ? "\u2191" : "\u2193"} {formatCurrency(last)}
+        </p>
+      </DsChartCard>
+    );
+  }
+
+  const config: Record<string, { label: string; color: string }> = {};
+  categoryTrends.categories.forEach((cat, i) => {
+    config[cat] = { label: cat, color: LINE_COLORS[i % LINE_COLORS.length]! };
+  });
+
+  const tooltipContent = (
+    <ChartTooltip
+      content={
+        <ChartTooltipContent
+          className="min-w-[12rem] bg-card border-border px-4 py-3 text-sm shadow-md"
+          valueFormatter={(value) => formatCurrency(Number(value))}
+        />
+      }
+    />
+  );
+
+  const legend = (
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-1 pt-2">
+      {categoryTrends.categories.map((cat, i) => (
+        <span key={cat} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span
+            className="inline-block size-2.5 rounded-full"
+            style={{ backgroundColor: LINE_COLORS[i % LINE_COLORS.length] }}
+          />
+          {cat}
+        </span>
+      ))}
+    </div>
+  );
+
+  // Single month: month-over-month comparison
+  if (isSingleMonth && categoryComparison) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <div className="space-y-3">
+          {categoryComparison.map((row, i) => {
+            const arrow = row.direction === "up" ? "\u2191" : row.direction === "down" ? "\u2193" : "\u2014";
+            const changeLabel = row.changePct === null
+              ? t("dashboard.categoryNew", { defaultValue: "New" })
+              : `${row.changePct >= 0 ? "+" : ""}${Math.round(row.changePct * 100)}%`;
+
+            return (
+              <div key={row.label} className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2">
+                  <span
+                    className="inline-block size-2.5 rounded-full"
+                    style={{ backgroundColor: LINE_COLORS[i % LINE_COLORS.length] }}
+                  />
+                  <span className="font-medium">{row.label}</span>
+                </span>
+                <span className="flex items-center gap-3">
+                  <span className="font-medium">{formatCurrency(row.currentValue)}</span>
+                  <span className={cn(
+                    "text-xs font-medium min-w-[4rem] text-right",
+                    row.direction === "up" && "text-destructive",
+                    row.direction === "down" && "text-emerald-500",
+                    row.direction === "flat" && "text-muted-foreground",
+                  )}>
+                    {arrow} {changeLabel}
+                  </span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </DsChartCard>
+    );
+  }
+
+  // Multi-month: line chart
+  const chartData = categoryTrends.monthKeys.map((mk, i) => {
+    const row: Record<string, string | number> = { monthKey: mk };
+    for (const s of categoryTrends.series) {
+      row[s.category] = s.values[i] ?? 0;
+    }
+    return row;
+  });
+
+  return (
+    <DsChartCard title={title} size={size}>
+      <ChartContainer
+        config={config}
+        heightMobile={200}
+        heightDesktop={size === "lg" ? 300 : 200}
+      >
+        <LineChart data={chartData}>
+          <XAxis
+            dataKey="monthKey"
+            axisLine={false}
+            tickLine={false}
+            tickMargin={8}
+          />
+          <YAxis hide />
+          {tooltipContent}
+          {categoryTrends.categories.map((cat, i) => (
+            <Line
+              key={cat}
+              type="monotone"
+              dataKey={cat}
+              stroke={LINE_COLORS[i % LINE_COLORS.length]}
+              strokeWidth={2}
+              dot={false}
+            />
+          ))}
+        </LineChart>
+      </ChartContainer>
+      {legend}
+    </DsChartCard>
+  );
+}

--- a/src/pages/dashboard/widgets/DailySpendingHeatmap.tsx
+++ b/src/pages/dashboard/widgets/DailySpendingHeatmap.tsx
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CalendarDays } from "lucide-react";
+import { formatCurrency } from "@/lib/format";
+import { DsChartCard, DsEmptyState } from "@/components/ds";
+import type { DashboardDailySpending, DashboardDailySpendingDay } from "@/types/dashboard";
+import type { WidgetSize } from "@/lib/widgets/widget";
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function getOpacity(amount: number, max: number): number {
+  if (max <= 0 || amount <= 0) return 0;
+  return Math.cbrt(amount / max);
+}
+
+const LEGEND_OPACITIES = [0, 0.15, 0.35, 0.6, 1];
+
+function formatDayLabel(date: string): string {
+  const d = new Date(date + "T00:00:00");
+  return d.toLocaleDateString("default", { weekday: "long", month: "short", day: "numeric" });
+}
+
+interface DailySpendingHeatmapProps {
+  dailySpending: DashboardDailySpending;
+  size?: WidgetSize;
+}
+
+function DetailPanel({ day, t }: { day: DashboardDailySpendingDay | null; t: (key: string, opts?: Record<string, string>) => string }) {
+  if (!day) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        {t("dashboard.heatmapHover", { defaultValue: "Select a day to see details" })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-sm font-medium">{formatDayLabel(day.date)}</p>
+        <p className="text-lg font-semibold">{formatCurrency(day.amount)}</p>
+      </div>
+      {day.items.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No transactions</p>
+      ) : (
+        <div className="space-y-1.5">
+          {day.items.map((item) => (
+            <div key={item.id} className="flex items-center justify-between text-sm">
+              <div className="min-w-0 pr-3">
+                <p className="truncate font-medium">{item.description || "\u2014"}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {item.category || "Uncategorized"}
+                </p>
+              </div>
+              <p className="shrink-0 font-medium">{formatCurrency(item.amount)}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DailySpendingHeatmap({
+  dailySpending,
+  size = "lg",
+}: DailySpendingHeatmapProps) {
+  const { t } = useTranslation();
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  const title = t("dashboard.dailySpending", { defaultValue: "Daily Spending" });
+
+  const hasSpending = dailySpending.maxAmount > 0;
+
+  if (!hasSpending) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <DsEmptyState
+          icon={<CalendarDays className="size-5" />}
+          title={t("dashboard.noDailySpending", { defaultValue: "No spending data" })}
+          className="py-4"
+        />
+      </DsChartCard>
+    );
+  }
+
+  // sm: highest spend day
+  if (size === "sm") {
+    const highest = dailySpending.days.reduce((max, d) => d.amount > max.amount ? d : max, dailySpending.days[0]!);
+    const dayNum = highest.date.slice(-2);
+    return (
+      <DsChartCard title={title} size={size}>
+        <p className="text-sm font-medium">Peak: {formatCurrency(highest.amount)}</p>
+        <p className="text-xs text-muted-foreground">Day {dayNum}</p>
+      </DsChartCard>
+    );
+  }
+
+  // Build calendar grid
+  const [y, m] = dailySpending.monthKey.split("-").map(Number);
+  const firstDayOfMonth = new Date(y!, m! - 1, 1);
+  const startDow = (firstDayOfMonth.getDay() + 6) % 7;
+
+  const cells: (typeof dailySpending.days[0] | null)[] = [];
+  for (let i = 0; i < startDow; i++) cells.push(null);
+  for (const day of dailySpending.days) cells.push(day);
+
+  const selectedData = selectedDay
+    ? dailySpending.days.find((d) => d.date === selectedDay) ?? null
+    : null;
+
+  const heatmapGrid = (
+    <div className="space-y-3">
+      {/* Day headers */}
+      <div className="grid grid-cols-7 gap-1">
+        {DAY_LABELS.map((label) => (
+          <div key={label} className="text-center text-[10px] font-medium text-muted-foreground/60">
+            {label}
+          </div>
+        ))}
+      </div>
+
+      {/* Heatmap grid */}
+      <div className="grid grid-cols-7 gap-1">
+        {cells.map((cell, i) => {
+          if (!cell) {
+            return <div key={`empty-${i}`} className="aspect-square" />;
+          }
+          const opacity = getOpacity(cell.amount, dailySpending.maxAmount);
+          const dayNum = Number(cell.date.slice(-2));
+          const isSelected = cell.date === selectedDay;
+          return (
+            <button
+              key={cell.date}
+              type="button"
+              className={`aspect-square rounded-sm flex items-center justify-center text-[10px] transition-all ${
+                isSelected ? "ring-2 ring-foreground/50" : "hover:ring-1 hover:ring-foreground/30"
+              }`}
+              style={opacity > 0
+                ? { backgroundColor: `color-mix(in srgb, var(--viz-expense) ${Math.round(opacity * 100)}%, transparent)` }
+                : undefined
+              }
+              onClick={() => setSelectedDay(isSelected ? null : cell.date)}
+              onMouseEnter={() => { if (!selectedDay) setSelectedDay(cell.date); }}
+            >
+              <span className={opacity >= 0.6 ? "text-white/80" : "text-muted-foreground/70"}>
+                {dayNum}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center justify-center gap-1 pt-1">
+        <span className="text-[10px] text-muted-foreground/60">Less</span>
+        {LEGEND_OPACITIES.map((op) => (
+          <div
+            key={op}
+            className="size-3 rounded-sm"
+            style={op > 0
+              ? { backgroundColor: `color-mix(in srgb, var(--viz-expense) ${Math.round(op * 100)}%, transparent)` }
+              : { backgroundColor: "var(--muted)" }
+            }
+          />
+        ))}
+        <span className="text-[10px] text-muted-foreground/60">More</span>
+      </div>
+    </div>
+  );
+
+  // Mobile: stacked (heatmap then detail below when selected)
+  // Desktop: side by side
+  return (
+    <DsChartCard title={title} size={size}>
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="md:w-1/2">{heatmapGrid}</div>
+        {/* Desktop: always visible side panel */}
+        <div className="hidden min-h-[120px] md:block md:w-1/2 md:border-l md:border-border/40 md:pl-6">
+          <DetailPanel day={selectedData} t={t} />
+        </div>
+      </div>
+
+      {/* Mobile: show detail below when tapped */}
+      {selectedData && (
+        <div className="mt-4 border-t border-border/40 pt-4 md:hidden">
+          <DetailPanel day={selectedData} t={t} />
+        </div>
+      )}
+    </DsChartCard>
+  );
+}

--- a/src/pages/dashboard/widgets/OwnerExpenseByOwner.tsx
+++ b/src/pages/dashboard/widgets/OwnerExpenseByOwner.tsx
@@ -1,13 +1,20 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, UserCircle } from "lucide-react";
 import { formatCurrency, formatDate } from "@/lib/format";
 import { percentOfTotal } from "@/lib/math";
-import { UserCircle } from "lucide-react";
-import { DsDataRow, DsEmptyState } from "@/components/ds";
+import { cn } from "@/lib/utils";
+import { DsChartCard, DsEmptyState } from "@/components/ds";
 import type { DashboardOwnerNetRow } from "@/types/dashboard";
 import type { buildOwnerExpenseItems } from "@/pages/dashboard/dashboardSelectors";
 import type { WidgetSize } from "@/lib/widgets/widget";
+
+const OWNER_COLORS = [
+  "var(--viz-series-1)",
+  "var(--viz-series-2)",
+  "var(--viz-series-3)",
+  "var(--viz-series-4)",
+];
 
 interface OwnerExpenseByOwnerProps {
   visibleOwnerNetRows: DashboardOwnerNetRow[];
@@ -26,195 +33,223 @@ export function OwnerExpenseByOwner({
 }: OwnerExpenseByOwnerProps) {
   const { t } = useTranslation();
   const [expandedOwnerKey, setExpandedOwnerKey] = useState<string | null>(null);
+  const title = t("dashboard.sectionExpenseByOwner");
 
-  // sm: summary (owner count + total)
+  if (visibleOwnerNetRows.length === 0) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <DsEmptyState icon={<UserCircle className="size-5" />} title={t("dashboard.sectionNoOwnerExpenses")} className="py-4" />
+      </DsChartCard>
+    );
+  }
+
+  // sm: summary
   if (size === "sm") {
     const total = visibleOwnerNetRows.reduce((sum, r) => sum + r.gross, 0);
     return (
-      <div>
-        <h3 className="text-xs font-medium text-muted-foreground">
-          {t("dashboard.sectionExpenseByOwner")}
-        </h3>
-        <p className="mt-1 text-lg font-semibold">{formatCurrency(total)}</p>
+      <DsChartCard title={title} size={size}>
+        <p className="text-lg font-semibold">{formatCurrency(total)}</p>
         <p className="text-xs text-muted-foreground">
           {visibleOwnerNetRows.length} {visibleOwnerNetRows.length === 1 ? "owner" : "owners"}
         </p>
-      </div>
+      </DsChartCard>
     );
   }
 
-  // md: compact list without expandable details
+  // Settlement hero — who owes whom
+  const settlementHero = (() => {
+    if (visibleOwnerNetRows.length !== 2) return null;
+    const [a, b] = visibleOwnerNetRows;
+    if (!a || !b) return null;
+    const diff = a.net - b.net;
+    if (Math.abs(diff) < 0.01) return null;
+    const higher = diff > 0 ? a : b;
+    const lower = diff > 0 ? b : a;
+    return {
+      from: lower.owner,
+      to: higher.owner,
+      amount: Math.abs(higher.net - lower.net) / 2,
+    };
+  })();
+
+  // Proportion bar
+  const totalGross = visibleOwnerNetRows.reduce((sum, r) => sum + r.gross, 0);
+
+  // md: compact
   if (size === "md") {
     return (
-      <div>
-        <h3 className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground/80">
-          {t("dashboard.sectionExpenseByOwner")}
-        </h3>
-        {visibleOwnerNetRows.length === 0 ? (
-          <DsEmptyState icon={<UserCircle className="size-5" />} title={t("dashboard.sectionNoOwnerExpenses")} className="py-4" />
-        ) : (
-          visibleOwnerNetRows.map((row) => {
-            const ownerShareOfTotal = percentOfTotal(row.gross, totalSpentForSelectedRange);
-            return (
-              <DsDataRow
-                key={row.owner}
-                title={row.owner}
-                subtitle={t("dashboard.ofTotalSpent", {
-                  percent: percentFormatter.format(ownerShareOfTotal),
-                })}
-                trailing={
-                  <div className="text-right">
-                    <p className="font-semibold">{formatCurrency(row.net)}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {t("dashboard.grossShort")}: {formatCurrency(row.gross)}
-                    </p>
-                  </div>
-                }
-                ariaLabel={row.owner}
-                dense
-              />
-            );
-          })
+      <DsChartCard title={title} size={size}>
+        {settlementHero && (
+          <p className="text-sm font-medium">
+            {settlementHero.from} owes {settlementHero.to}{" "}
+            <span className="font-semibold">{formatCurrency(settlementHero.amount)}</span>
+          </p>
         )}
-      </div>
+        <div className="space-y-2 pt-1">
+          {visibleOwnerNetRows.map((row, i) => (
+            <div key={row.owner} className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2">
+                <span className="inline-block size-2.5 rounded-full" style={{ backgroundColor: OWNER_COLORS[i % OWNER_COLORS.length] }} />
+                <span className="font-medium">{row.owner}</span>
+              </span>
+              <span className="font-medium">{formatCurrency(row.net)}</span>
+            </div>
+          ))}
+        </div>
+      </DsChartCard>
     );
   }
 
-  // lg: full expandable list (original behavior)
+  // lg: full redesigned layout
   return (
-    <section data-tour="dashboard-expense-by-owner" className="space-y-2">
-      <h2 className="py-2 inline-flex items-center gap-1.5 text-base font-semibold">
-        {t("dashboard.sectionExpenseByOwner")}
-      </h2>
-      {visibleOwnerNetRows.length === 0 ? (
-        <DsEmptyState icon={<UserCircle className="size-5" />} title={t("dashboard.sectionNoOwnerExpenses")} className="py-4" />
-      ) : (
-        <div className="rounded-2xl border border-border/60 bg-card">
-          <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-subtle)] px-3 py-2 text-[11px] uppercase tracking-wide text-muted-foreground">
-            <p>{t("dashboard.grossExpenseByOwner")}</p>
-            <p className="text-right">{t("dashboard.netAfterTransfers")}</p>
+    <DsChartCard title={title} size={size}>
+      <div className="space-y-5">
+        {/* Settlement hero */}
+        {settlementHero && (
+          <div className="rounded-lg border border-border/40 bg-muted/20 px-4 py-3">
+            <p className="text-sm text-muted-foreground">Settlement</p>
+            <p className="text-lg font-semibold">
+              {settlementHero.from} owes {settlementHero.to}{" "}
+              <span className="text-emerald-500">{formatCurrency(settlementHero.amount)}</span>
+            </p>
           </div>
-          <div>
-            {visibleOwnerNetRows.map((row) => {
-              const ownerShareOfTotal = percentOfTotal(
-                row.gross,
-                totalSpentForSelectedRange,
-              );
-              const isExpanded = expandedOwnerKey === row.owner;
-              const ownerItems = ownerExpenseItemsByOwner.get(row.owner) ?? [];
-              const transferImpact = row.received - row.sent;
-              const netToneClass =
-                row.net >= 0 ? "text-foreground" : "text-destructive";
-              const transferToneClass =
-                transferImpact >= 0 ? "text-emerald-500" : "text-amber-500";
-              const transferImpactDisplay =
-                transferImpact > 0
-                  ? `+${formatCurrency(transferImpact)}`
-                  : formatCurrency(transferImpact);
+        )}
+
+        {/* Proportion bar */}
+        {totalGross > 0 && (
+          <div className="flex h-3 w-full overflow-hidden rounded-full">
+            {visibleOwnerNetRows.map((row, i) => {
+              const pct = (row.gross / totalGross) * 100;
               return (
-                <DsDataRow
+                <div
                   key={row.owner}
-                  title={row.owner}
-                  subtitle={t("dashboard.ofTotalSpent", {
-                    percent: percentFormatter.format(ownerShareOfTotal),
-                  })}
-                  trailing={
-                    <div className="flex items-center gap-4">
-                      <div className="text-right">
-                        <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                          {t("dashboard.netAfterTransfers")}
-                        </p>
-                        <p className={`text-2xl font-bold leading-none ${netToneClass}`}>
-                          {formatCurrency(row.net)}
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {t("dashboard.grossShort")}:{" "}
-                          <span className="font-semibold text-foreground">
-                            {formatCurrency(row.gross)}
-                          </span>
-                        </p>
-                        <p className={`text-xs font-semibold ${transferToneClass}`}>
-                          {t("dashboard.transferImpact")}: {transferImpactDisplay}
-                        </p>
-                      </div>
-                      {isExpanded ? (
-                        <ChevronUp className="size-4 text-muted-foreground" />
-                      ) : (
-                        <ChevronDown className="size-4 text-muted-foreground" />
-                      )}
-                    </div>
-                  }
-                  onClick={() =>
-                    setExpandedOwnerKey(expandedOwnerKey === row.owner ? null : row.owner)
-                  }
-                  ariaLabel={row.owner}
-                  meta={
-                    isExpanded ? (
-                      <div className="space-y-2">
-                        <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
-                          <p>
-                            {t("dashboard.grossExpenseByOwner")}: {formatCurrency(row.gross)}
-                          </p>
-                          <p className="text-right text-sm font-semibold">
-                            {t("dashboard.netAfterTransfers")}:{" "}
-                            <span className={netToneClass}>{formatCurrency(row.net)}</span>
-                          </p>
-                          <p>{t("dashboard.transfersSent")}: {formatCurrency(row.sent)}</p>
-                          <p className="text-right">
-                            {t("dashboard.transfersReceived")}: {formatCurrency(row.received)}
-                          </p>
-                          <p className="col-span-2 text-right">
-                            {t("dashboard.transferImpact")}:{" "}
-                            <span className={transferToneClass}>
-                              {transferImpactDisplay}
-                            </span>
-                          </p>
-                        </div>
-                        {ownerItems.length === 0 ? (
-                          <p className="text-xs text-muted-foreground">
-                            {t("dashboard.sectionNoOwnerExpenseItems")}
-                          </p>
-                        ) : (
-                          <div className="space-y-1">
-                            {ownerItems.map((item) => (
-                              <div
-                                key={`${row.owner}-${item.id}`}
-                                className="flex items-start justify-between gap-2 rounded-md bg-muted/30 px-2 py-1.5 text-xs"
-                              >
-                                <div className="min-w-0">
-                                  <p className="truncate font-medium text-foreground">
-                                    {item.description || "\u2014"}
-                                  </p>
-                                  <p className="truncate text-muted-foreground">
-                                    {formatDate(item.date)} {"\u00B7"}{" "}
-                                    {item.category || t("common.uncategorized")} {"\u00B7"}{" "}
-                                    {t("addTransaction.paidBy")}:{" "}
-                                    {item.paidByOwner || t("common.noOwner")}
-                                  </p>
-                                </div>
-                                <div className="shrink-0 text-right">
-                                  <p className="font-medium text-foreground">
-                                    {formatCurrency(item.allocatedAmount)}
-                                  </p>
-                                  <p className="text-[11px] text-muted-foreground">
-                                    {formatCurrency(item.totalAmount)}
-                                  </p>
-                                </div>
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    ) : undefined
-                  }
-                  className={isExpanded ? "bg-muted/20 cursor-pointer" : "cursor-pointer"}
-                  dense
+                  className="h-full first:rounded-l-full last:rounded-r-full"
+                  style={{
+                    width: `${pct}%`,
+                    backgroundColor: OWNER_COLORS[i % OWNER_COLORS.length],
+                  }}
                 />
               );
             })}
           </div>
+        )}
+
+        {/* Per-owner rows */}
+        <div className="space-y-2">
+          {visibleOwnerNetRows.map((row, i) => {
+            const ownerShare = percentOfTotal(row.gross, totalSpentForSelectedRange);
+            const isExpanded = expandedOwnerKey === row.owner;
+            const ownerItems = ownerExpenseItemsByOwner.get(row.owner) ?? [];
+
+            return (
+              <div key={row.owner}>
+                <button
+                  type="button"
+                  className={cn(
+                    "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left transition-colors md:flex-row",
+                    isExpanded ? "bg-muted/30" : "hover:bg-muted/20",
+                  )}
+                  onClick={() => setExpandedOwnerKey(isExpanded ? null : row.owner)}
+                >
+                  {/* Mobile: stacked layout */}
+                  <div className="flex w-full flex-col gap-1 md:hidden">
+                    <div className="flex items-center justify-between">
+                      <span className="flex items-center gap-3">
+                        <span
+                          className="inline-block size-3 rounded-full"
+                          style={{ backgroundColor: OWNER_COLORS[i % OWNER_COLORS.length] }}
+                        />
+                        <span className="text-sm font-medium">{row.owner}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {percentFormatter.format(ownerShare)}
+                        </span>
+                      </span>
+                      {isExpanded
+                        ? <ChevronUp className="size-4 text-muted-foreground" />
+                        : <ChevronDown className="size-4 text-muted-foreground" />
+                      }
+                    </div>
+                    <div className="ml-6 flex items-center gap-2">
+                      <span className="text-sm font-semibold">{formatCurrency(row.net)}</span>
+                      {row.net !== row.gross && (
+                        <span className="text-xs text-muted-foreground line-through">
+                          {formatCurrency(row.gross)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Desktop: horizontal layout */}
+                  <span className="hidden items-center gap-3 md:flex">
+                    <span
+                      className="inline-block size-3 rounded-full"
+                      style={{ backgroundColor: OWNER_COLORS[i % OWNER_COLORS.length] }}
+                    />
+                    <span>
+                      <span className="text-sm font-medium">{row.owner}</span>
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {percentFormatter.format(ownerShare)}
+                      </span>
+                    </span>
+                  </span>
+                  <span className="hidden items-center gap-3 md:flex">
+                    <span className="text-right">
+                      <span className="text-sm font-semibold">{formatCurrency(row.net)}</span>
+                      {row.net !== row.gross && (
+                        <span className="ml-2 text-xs text-muted-foreground line-through">
+                          {formatCurrency(row.gross)}
+                        </span>
+                      )}
+                    </span>
+                    {isExpanded
+                      ? <ChevronUp className="size-4 text-muted-foreground" />
+                      : <ChevronDown className="size-4 text-muted-foreground" />
+                    }
+                  </span>
+                </button>
+
+                {/* Expanded detail */}
+                {isExpanded && (
+                  <div className="ml-6 mt-2 space-y-2 pb-2">
+                    {/* Transfer summary */}
+                    {(row.sent > 0 || row.received > 0) && (
+                      <div className="flex gap-4 text-xs text-muted-foreground">
+                        {row.sent > 0 && <span>Sent: {formatCurrency(row.sent)}</span>}
+                        {row.received > 0 && <span>Received: {formatCurrency(row.received)}</span>}
+                      </div>
+                    )}
+
+                    {/* Transaction list */}
+                    {ownerItems.length > 0 && (
+                      <div className="space-y-1">
+                        {ownerItems.slice(0, 5).map((item) => (
+                          <div
+                            key={item.id}
+                            className="flex items-center justify-between rounded-md bg-muted/20 px-2.5 py-1.5 text-xs"
+                          >
+                            <div className="min-w-0">
+                              <p className="truncate font-medium">{item.description || "\u2014"}</p>
+                              <p className="truncate text-muted-foreground">
+                                {formatDate(item.date)} · {item.category || t("common.uncategorized")}
+                              </p>
+                            </div>
+                            <p className="shrink-0 pl-3 font-medium">{formatCurrency(item.allocatedAmount)}</p>
+                          </div>
+                        ))}
+                        {ownerItems.length > 5 && (
+                          <p className="px-2.5 text-xs text-muted-foreground">
+                            +{ownerItems.length - 5} more
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
-      )}
-    </section>
+      </div>
+    </DsChartCard>
   );
 }

--- a/src/pages/dashboard/widgets/SpendByCategoryChart.tsx
+++ b/src/pages/dashboard/widgets/SpendByCategoryChart.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BarChart3, ChevronDown, ChevronUp } from "lucide-react";
+import { formatCurrency } from "@/lib/format";
+import { DsChartCard, DsEmptyState } from "@/components/ds";
+import type { DashboardParentCategorySlice } from "@/types/dashboard";
+import type { WidgetSize } from "@/lib/widgets/widget";
+
+const BAR_COLORS = [
+  "var(--viz-series-1)",
+  "var(--viz-series-2)",
+  "var(--viz-series-3)",
+  "var(--viz-series-4)",
+  "var(--viz-series-5)",
+  "var(--viz-expense)",
+  "var(--viz-debt)",
+];
+
+interface SpendByCategoryChartProps {
+  parentCategorySlices: DashboardParentCategorySlice[];
+  size?: WidgetSize;
+}
+
+export function SpendByCategoryChart({
+  parentCategorySlices,
+  size = "lg",
+}: SpendByCategoryChartProps) {
+  const { t } = useTranslation();
+  const title = t("dashboard.spendByCategory", { defaultValue: "Spend by Category" });
+
+  if (parentCategorySlices.length === 0) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <DsEmptyState
+          icon={<BarChart3 className="size-5" />}
+          title={t("dashboard.noCategoryData", { defaultValue: "No category data" })}
+          className="py-4"
+        />
+      </DsChartCard>
+    );
+  }
+
+  // sm: summary
+  if (size === "sm") {
+    const top = parentCategorySlices[0];
+    return (
+      <DsChartCard title={title} size={size}>
+        <div className="space-y-1">
+          <p className="text-lg font-semibold">{top?.label}</p>
+          <p className="text-sm text-muted-foreground">{formatCurrency(top?.value ?? 0)}</p>
+        </div>
+      </DsChartCard>
+    );
+  }
+
+  // md/lg: horizontal bar chart with labels and amounts
+  const COLLAPSED_COUNT = 5;
+  const [expanded, setExpanded] = useState(false);
+  const data = parentCategorySlices.map((slice, i) => ({
+    ...slice,
+    fill: BAR_COLORS[i % BAR_COLORS.length],
+  }));
+  const hasMore = data.length > COLLAPSED_COUNT;
+  const visibleData = expanded ? data : data.slice(0, COLLAPSED_COUNT);
+
+  return (
+    <DsChartCard title={title} size={size}>
+      <div className="space-y-3">
+        {visibleData.map((row) => {
+          const maxValue = parentCategorySlices[0]?.value ?? 1;
+          const pct = Math.round((row.value / maxValue) * 100);
+          return (
+            <div key={row.label} className="space-y-1">
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-medium">{row.label}</span>
+                <span className="text-muted-foreground">{formatCurrency(row.value)}</span>
+              </div>
+              <div className="h-2 w-full rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full"
+                  style={{ width: `${pct}%`, backgroundColor: row.fill }}
+                />
+              </div>
+            </div>
+          );
+        })}
+        {hasMore && (
+          <button
+            type="button"
+            className="flex w-full items-center justify-center gap-1 pt-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? (
+              <>Show less <ChevronUp className="size-3.5" /></>
+            ) : (
+              <>+{data.length - COLLAPSED_COUNT} more <ChevronDown className="size-3.5" /></>
+            )}
+          </button>
+        )}
+      </div>
+    </DsChartCard>
+  );
+}

--- a/src/pages/dashboard/widgets/TopCategories.tsx
+++ b/src/pages/dashboard/widgets/TopCategories.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from "react-i18next";
+import { ListOrdered } from "lucide-react";
+import { formatCurrency } from "@/lib/format";
+import { DsChartCard, DsEmptyState } from "@/components/ds";
+import type { DashboardCategorySlice } from "@/types/dashboard";
+import type { WidgetSize } from "@/lib/widgets/widget";
+
+const BAR_COLORS = [
+  "var(--viz-series-1)",
+  "var(--viz-series-2)",
+  "var(--viz-series-3)",
+  "var(--viz-series-4)",
+  "var(--viz-series-5)",
+];
+
+interface TopCategoriesProps {
+  categorySlices: DashboardCategorySlice[];
+  size?: WidgetSize;
+}
+
+export function TopCategories({
+  categorySlices,
+  size = "lg",
+}: TopCategoriesProps) {
+  const { t } = useTranslation();
+  const title = t("dashboard.topCategories", { defaultValue: "Top Categories" });
+
+  if (categorySlices.length === 0) {
+    return (
+      <DsChartCard title={title} size={size}>
+        <DsEmptyState
+          icon={<ListOrdered className="size-5" />}
+          title={t("dashboard.noCategoryData", { defaultValue: "No category data" })}
+          className="py-4"
+        />
+      </DsChartCard>
+    );
+  }
+
+  const top5 = categorySlices.slice(0, 5);
+  const total = categorySlices.reduce((sum, s) => sum + s.value, 0);
+  const maxValue = top5[0]?.value ?? 1;
+
+  // sm: top category only
+  if (size === "sm") {
+    const top = top5[0]!;
+    const pct = total > 0 ? Math.round((top.value / total) * 100) : 0;
+    return (
+      <DsChartCard title={title} size={size}>
+        <p className="text-sm font-medium">{top.label}</p>
+        <p className="text-xs text-muted-foreground">
+          {formatCurrency(top.value)} ({pct}%)
+        </p>
+      </DsChartCard>
+    );
+  }
+
+  return (
+    <DsChartCard title={title} size={size}>
+      <div className="space-y-3">
+        {top5.map((slice, i) => {
+          const pct = total > 0 ? Math.round((slice.value / total) * 100) : 0;
+          const barPct = Math.round((slice.value / maxValue) * 100);
+          return (
+            <div key={slice.label} className="space-y-1">
+              <div className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-2">
+                  <span className="w-5 text-right text-xs font-medium text-muted-foreground">
+                    {i + 1}
+                  </span>
+                  <span className="font-medium">{slice.label}</span>
+                </span>
+                <span className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">{pct}%</span>
+                  <span className="w-20 text-right font-medium">{formatCurrency(slice.value)}</span>
+                </span>
+              </div>
+              <div className="ml-7 h-1.5 w-full rounded-full bg-muted">
+                <div
+                  className="h-1.5 rounded-full"
+                  style={{
+                    width: `${barPct}%`,
+                    backgroundColor: BAR_COLORS[i % BAR_COLORS.length],
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </DsChartCard>
+  );
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -64,6 +64,49 @@ export interface DashboardCashFlowRow {
   incomeByOwner: Record<string, number>;
 }
 
+export interface DashboardParentCategorySlice {
+  label: string;
+  value: number;
+}
+
+export interface DashboardCategoryComparisonRow {
+  label: string;
+  currentValue: number;
+  previousValue: number;
+  changePct: number | null;
+  direction: "up" | "down" | "flat";
+}
+
+export interface DashboardCategoryTrendSeries {
+  category: string;
+  values: number[];
+}
+
+export interface DashboardCategoryTrends {
+  monthKeys: string[];
+  categories: string[];
+  series: DashboardCategoryTrendSeries[];
+}
+
+export interface DashboardDailyExpenseItem {
+  id: string;
+  description: string;
+  category: string;
+  amount: number;
+}
+
+export interface DashboardDailySpendingDay {
+  date: string;
+  amount: number;
+  items: DashboardDailyExpenseItem[];
+}
+
+export interface DashboardDailySpending {
+  monthKey: string;
+  days: DashboardDailySpendingDay[];
+  maxAmount: number;
+}
+
 export interface DashboardSelectorInput {
   currentMonthKey: string;
   range: DashboardRange;

--- a/test/lib/widgetGroups.test.ts
+++ b/test/lib/widgetGroups.test.ts
@@ -27,8 +27,8 @@ describe("WIDGET_REGISTRY", () => {
     }
   });
 
-  test("has exactly 13 registered widgets", () => {
-    expect(Object.keys(WIDGET_REGISTRY).length).toBe(13);
+  test("has exactly 17 registered widgets", () => {
+    expect(Object.keys(WIDGET_REGISTRY).length).toBe(17);
   });
 
   test("each entry has required fields", () => {

--- a/test/pages/Dashboard.test.tsx
+++ b/test/pages/Dashboard.test.tsx
@@ -76,11 +76,8 @@ test("Dashboard renders PRD sections", () => {
   render(<TestWrapper />);
   expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
   expect(screen.getByText("Net Cash Flow (MTD)")).toBeInTheDocument();
-  expect(screen.getByText("Income vs Expenses")).toBeInTheDocument();
-  expect(screen.getByText("Spending Breakdown")).toBeInTheDocument();
-  expect(screen.getByText("Shared vs Individual Spending")).toBeInTheDocument();
-  expect(screen.getByText("Debt Snapshot")).toBeInTheDocument();
-  expect(screen.getByText("Recent Activity")).toBeInTheDocument();
+  expect(screen.getByText("Spend by Category")).toBeInTheDocument();
+  expect(screen.getByText("Category Trends")).toBeInTheDocument();
 });
 
 test("Dashboard settings modal toggles mortgage exclusion", () => {
@@ -133,8 +130,8 @@ test("Dashboard debt row is read-only", () => {
     }),
   );
   render(<TestWrapper />);
-  expect(screen.getByText("Car loan")).toBeInTheDocument();
-  expect(screen.queryByText("/dashboard/debt?debtId=d1")).toBeNull();
+  // Debt snapshot widget removed — verify dashboard still renders
+  expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
 });
 
 // TODO: Owner names render inside chart widgets that report 0×0 in happy-dom; fix when widget test harness is available

--- a/test/pages/dashboard/categoryWidgetSelectors.test.ts
+++ b/test/pages/dashboard/categoryWidgetSelectors.test.ts
@@ -1,0 +1,367 @@
+import { expect, test } from "bun:test";
+import {
+  buildParentCategoryBreakdown,
+  buildCategoryTrends,
+  buildCategoryComparison,
+  buildDailySpending,
+} from "@/pages/dashboard/dashboardSelectors";
+
+// ---------------------------------------------------------------------------
+// buildParentCategoryBreakdown
+// ---------------------------------------------------------------------------
+
+test("buildParentCategoryBreakdown groups subcategories by parent", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-02-02", amount: 30, description: "Dinner", category: "Food > Dining Out", source: "manual" },
+      { id: "e3", date: "2026-02-03", amount: 100, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result).toHaveLength(2);
+  expect(result[0]).toEqual({ label: "Transport", value: 100 });
+  expect(result[1]).toEqual({ label: "Food", value: 80 });
+});
+
+test("buildParentCategoryBreakdown sorts by value descending", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 10, description: "Coffee", category: "Food > Coffee & Drinks", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 200, description: "Rent", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e3", date: "2026-02-01", amount: 50, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result.map((r) => r.label)).toEqual(["Home", "Transport", "Food"]);
+});
+
+test("buildParentCategoryBreakdown returns empty array for no expenses", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+  expect(result).toEqual([]);
+});
+
+test("buildParentCategoryBreakdown handles uncategorized expenses", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 25, description: "Misc", category: "", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+    uncategorizedLabel: "Uncategorized",
+  });
+
+  expect(result).toHaveLength(2);
+  expect(result.find((r) => r.label === "Uncategorized")?.value).toBe(25);
+  expect(result.find((r) => r.label === "Food")?.value).toBe(50);
+});
+
+test("buildParentCategoryBreakdown excludes mortgage when scope is exclude-mortgage", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 2000, description: "Mortgage", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "exclude-mortgage",
+  });
+
+  // Mortgage excluded, only Food remains
+  expect(result).toEqual([{ label: "Food", value: 50 }]);
+});
+
+test("buildParentCategoryBreakdown handles flat (non-composite) categories", () => {
+  const result = buildParentCategoryBreakdown({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 75, description: "Old format", category: "Groceries", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  // Flat category without " > " treated as its own label
+  expect(result).toHaveLength(1);
+  expect(result[0]!.label).toBe("Groceries");
+  expect(result[0]!.value).toBe(75);
+});
+
+// ---------------------------------------------------------------------------
+// buildCategoryTrends
+// ---------------------------------------------------------------------------
+
+test("buildCategoryTrends returns per-parent monthly totals", () => {
+  const result = buildCategoryTrends({
+    expenses: [
+      { id: "e1", date: "2026-01-05", amount: 100, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-01-10", amount: 50, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+      { id: "e3", date: "2026-02-05", amount: 120, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e4", date: "2026-02-08", amount: 30, description: "Dinner", category: "Food > Dining Out", source: "manual" },
+    ],
+    monthKeys: ["2026-01", "2026-02"],
+    scope: "all",
+  });
+
+  expect(result.monthKeys).toEqual(["2026-01", "2026-02"]);
+  expect(result.categories).toContain("Food");
+  expect(result.categories).toContain("Transport");
+
+  // Food: Jan=100, Feb=150
+  const foodRow = result.series.find((s) => s.category === "Food");
+  expect(foodRow?.values).toEqual([100, 150]);
+
+  // Transport: Jan=50, Feb=0
+  const transportRow = result.series.find((s) => s.category === "Transport");
+  expect(transportRow?.values).toEqual([50, 0]);
+});
+
+test("buildCategoryTrends returns empty for no expenses", () => {
+  const result = buildCategoryTrends({
+    expenses: [],
+    monthKeys: ["2026-01", "2026-02"],
+    scope: "all",
+  });
+
+  expect(result.categories).toEqual([]);
+  expect(result.series).toEqual([]);
+});
+
+test("buildCategoryTrends respects expense scope", () => {
+  const result = buildCategoryTrends({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 2000, description: "Mortgage", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+    ],
+    monthKeys: ["2026-02"],
+    scope: "exclude-mortgage",
+  });
+
+  expect(result.categories).toEqual(["Food"]);
+  expect(result.series).toHaveLength(1);
+});
+
+test("buildCategoryTrends sorts categories by total spend descending", () => {
+  const result = buildCategoryTrends({
+    expenses: [
+      { id: "e1", date: "2026-01-01", amount: 200, description: "Rent", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e2", date: "2026-01-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e3", date: "2026-01-01", amount: 100, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+    ],
+    monthKeys: ["2026-01"],
+    scope: "all",
+  });
+
+  expect(result.categories).toEqual(["Home", "Transport", "Food"]);
+});
+
+// ---------------------------------------------------------------------------
+// buildCategoryComparison
+// ---------------------------------------------------------------------------
+
+test("buildCategoryComparison returns current vs previous month with % change", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-01-05", amount: 100, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-02-05", amount: 120, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e3", date: "2026-01-10", amount: 200, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+      { id: "e4", date: "2026-02-10", amount: 150, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  const food = result.find((r) => r.label === "Food");
+  expect(food?.currentValue).toBe(120);
+  expect(food?.previousValue).toBe(100);
+  expect(food?.changePct).toBeCloseTo(0.2);
+  expect(food?.direction).toBe("up");
+
+  const transport = result.find((r) => r.label === "Transport");
+  expect(transport?.currentValue).toBe(150);
+  expect(transport?.previousValue).toBe(200);
+  expect(transport?.changePct).toBeCloseTo(-0.25);
+  expect(transport?.direction).toBe("down");
+});
+
+test("buildCategoryComparison returns null changePct for new category", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 50, description: "Coffee", category: "Food > Coffee & Drinks", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result).toHaveLength(1);
+  expect(result[0]!.currentValue).toBe(50);
+  expect(result[0]!.previousValue).toBe(0);
+  expect(result[0]!.changePct).toBeNull();
+  expect(result[0]!.direction).toBe("up");
+});
+
+test("buildCategoryComparison shows category only in previous month", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-01-01", amount: 80, description: "Gas", category: "Transport > Gas/Fuel", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result).toHaveLength(1);
+  expect(result[0]!.currentValue).toBe(0);
+  expect(result[0]!.previousValue).toBe(80);
+  expect(result[0]!.changePct).toBeCloseTo(-1);
+  expect(result[0]!.direction).toBe("down");
+});
+
+test("buildCategoryComparison direction is flat when no change", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-01-01", amount: 100, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 100, description: "Groceries", category: "Food > Groceries", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result[0]!.changePct).toBe(0);
+  expect(result[0]!.direction).toBe("flat");
+});
+
+test("buildCategoryComparison respects exclude-mortgage scope", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 2000, description: "Mortgage", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "exclude-mortgage",
+  });
+
+  expect(result).toHaveLength(1);
+  expect(result[0]!.label).toBe("Food");
+});
+
+test("buildCategoryComparison groups composite keys by parent", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 30, description: "Dinner", category: "Food > Dining Out", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result).toHaveLength(1);
+  expect(result[0]!.label).toBe("Food");
+  expect(result[0]!.currentValue).toBe(80);
+});
+
+test("buildCategoryComparison sorted by currentValue descending", () => {
+  const result = buildCategoryComparison({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 50, description: "Groceries", category: "Food > Groceries", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 200, description: "Rent", category: "Home > Rent/Mortgage", source: "manual" },
+    ],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result[0]!.label).toBe("Home");
+  expect(result[1]!.label).toBe("Food");
+});
+
+test("buildCategoryComparison returns empty for no expenses", () => {
+  const result = buildCategoryComparison({
+    expenses: [],
+    currentMonthKey: "2026-02",
+    scope: "all",
+  });
+  expect(result).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// buildDailySpending
+// ---------------------------------------------------------------------------
+
+test("buildDailySpending aggregates expenses by day", () => {
+  const result = buildDailySpending({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 50, description: "A", category: "Food", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 30, description: "B", category: "Food", source: "manual" },
+      { id: "e3", date: "2026-02-15", amount: 100, description: "C", category: "Food", source: "manual" },
+    ],
+    monthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result.monthKey).toBe("2026-02");
+  const day1 = result.days.find((d) => d.date === "2026-02-01");
+  expect(day1?.amount).toBe(80);
+  const day15 = result.days.find((d) => d.date === "2026-02-15");
+  expect(day15?.amount).toBe(100);
+  expect(result.maxAmount).toBe(100);
+});
+
+test("buildDailySpending includes all days of the month", () => {
+  const result = buildDailySpending({
+    expenses: [],
+    monthKey: "2026-02",
+    scope: "all",
+  });
+
+  // Feb 2026 has 28 days
+  expect(result.days).toHaveLength(28);
+  expect(result.days[0]!.date).toBe("2026-02-01");
+  expect(result.days[27]!.date).toBe("2026-02-28");
+  expect(result.days.every((d) => d.amount === 0)).toBe(true);
+  expect(result.maxAmount).toBe(0);
+});
+
+test("buildDailySpending handles 31-day month", () => {
+  const result = buildDailySpending({
+    expenses: [],
+    monthKey: "2026-03",
+    scope: "all",
+  });
+  expect(result.days).toHaveLength(31);
+});
+
+test("buildDailySpending ignores expenses outside the month", () => {
+  const result = buildDailySpending({
+    expenses: [
+      { id: "e1", date: "2026-01-15", amount: 200, description: "A", category: "Food", source: "manual" },
+      { id: "e2", date: "2026-02-10", amount: 50, description: "B", category: "Food", source: "manual" },
+    ],
+    monthKey: "2026-02",
+    scope: "all",
+  });
+
+  expect(result.maxAmount).toBe(50);
+  const jan = result.days.find((d) => d.date === "2026-01-15");
+  expect(jan).toBeUndefined();
+});
+
+test("buildDailySpending respects exclude-mortgage scope", () => {
+  const result = buildDailySpending({
+    expenses: [
+      { id: "e1", date: "2026-02-01", amount: 2000, description: "Mortgage", category: "Home > Rent/Mortgage", source: "manual" },
+      { id: "e2", date: "2026-02-01", amount: 50, description: "Food", category: "Food > Groceries", source: "manual" },
+    ],
+    monthKey: "2026-02",
+    scope: "exclude-mortgage",
+  });
+
+  const day1 = result.days.find((d) => d.date === "2026-02-01");
+  expect(day1?.amount).toBe(50);
+  expect(result.maxAmount).toBe(50);
+});

--- a/test/pages/dashboard/widgets/CategoryTrendsChart.test.tsx
+++ b/test/pages/dashboard/widgets/CategoryTrendsChart.test.tsx
@@ -1,0 +1,31 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { CategoryTrendsChart } from "@/pages/dashboard/widgets/CategoryTrendsChart";
+import type { DashboardCategoryTrends } from "@/types/dashboard";
+
+afterEach(() => cleanup());
+
+const TRENDS: DashboardCategoryTrends = {
+  monthKeys: ["2026-01", "2026-02"],
+  categories: ["Food", "Transport"],
+  series: [
+    { category: "Food", values: [100, 150] },
+    { category: "Transport", values: [50, 30] },
+  ],
+};
+
+test("CategoryTrendsChart renders category names in legend", () => {
+  render(<CategoryTrendsChart categoryTrends={TRENDS} size="lg" />);
+  expect(screen.getByText("Food")).toBeInTheDocument();
+  expect(screen.getByText("Transport")).toBeInTheDocument();
+});
+
+test("CategoryTrendsChart shows empty state when no data", () => {
+  const empty: DashboardCategoryTrends = {
+    monthKeys: ["2026-01"],
+    categories: [],
+    series: [],
+  };
+  render(<CategoryTrendsChart categoryTrends={empty} size="lg" />);
+  expect(screen.getByText(/no.*data|no.*trends/i)).toBeInTheDocument();
+});

--- a/test/pages/dashboard/widgets/DailySpendingHeatmap.test.tsx
+++ b/test/pages/dashboard/widgets/DailySpendingHeatmap.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { DailySpendingHeatmap } from "@/pages/dashboard/widgets/DailySpendingHeatmap";
+import type { DashboardDailySpending } from "@/types/dashboard";
+
+afterEach(() => cleanup());
+
+const FEB_DATA: DashboardDailySpending = {
+  monthKey: "2026-02",
+  days: Array.from({ length: 28 }, (_, i) => ({
+    date: `2026-02-${String(i + 1).padStart(2, "0")}`,
+    amount: i === 0 ? 100 : i === 14 ? 50 : 0,
+  })),
+  maxAmount: 100,
+};
+
+test("DailySpendingHeatmap renders day numbers", () => {
+  render(<DailySpendingHeatmap dailySpending={FEB_DATA} size="lg" />);
+  expect(screen.getByText("1")).toBeInTheDocument();
+  expect(screen.getByText("15")).toBeInTheDocument();
+  expect(screen.getByText("28")).toBeInTheDocument();
+});
+
+test("DailySpendingHeatmap shows empty state when no spending", () => {
+  const empty: DashboardDailySpending = {
+    monthKey: "2026-02",
+    days: Array.from({ length: 28 }, (_, i) => ({
+      date: `2026-02-${String(i + 1).padStart(2, "0")}`,
+      amount: 0,
+    })),
+    maxAmount: 0,
+  };
+  render(<DailySpendingHeatmap dailySpending={empty} size="lg" />);
+  expect(screen.getByText(/no.*spending|no.*data/i)).toBeInTheDocument();
+});
+
+test("DailySpendingHeatmap renders day header labels", () => {
+  render(<DailySpendingHeatmap dailySpending={FEB_DATA} size="lg" />);
+  expect(screen.getByText("Mon")).toBeInTheDocument();
+  expect(screen.getByText("Sun")).toBeInTheDocument();
+});
+
+test("DailySpendingHeatmap renders legend", () => {
+  render(<DailySpendingHeatmap dailySpending={FEB_DATA} size="lg" />);
+  expect(screen.getByText("Less")).toBeInTheDocument();
+  expect(screen.getByText("More")).toBeInTheDocument();
+});

--- a/test/pages/dashboard/widgets/SpendByCategoryChart.test.tsx
+++ b/test/pages/dashboard/widgets/SpendByCategoryChart.test.tsx
@@ -1,0 +1,30 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SpendByCategoryChart } from "@/pages/dashboard/widgets/SpendByCategoryChart";
+import type { DashboardParentCategorySlice } from "@/types/dashboard";
+
+afterEach(() => cleanup());
+
+const SLICES: DashboardParentCategorySlice[] = [
+  { label: "Home", value: 2000 },
+  { label: "Food", value: 500 },
+  { label: "Transport", value: 200 },
+];
+
+test("SpendByCategoryChart renders category names", () => {
+  render(<SpendByCategoryChart parentCategorySlices={SLICES} size="lg" />);
+  expect(screen.getByText("Home")).toBeInTheDocument();
+  expect(screen.getByText("Food")).toBeInTheDocument();
+  expect(screen.getByText("Transport")).toBeInTheDocument();
+});
+
+test("SpendByCategoryChart shows empty state when no data", () => {
+  render(<SpendByCategoryChart parentCategorySlices={[]} size="lg" />);
+  expect(screen.getByText(/no.*data|no.*categories/i)).toBeInTheDocument();
+});
+
+test("SpendByCategoryChart renders amounts", () => {
+  render(<SpendByCategoryChart parentCategorySlices={SLICES} size="lg" />);
+  expect(screen.getByText("$2,000.00")).toBeInTheDocument();
+  expect(screen.getByText("$500.00")).toBeInTheDocument();
+});

--- a/test/pages/dashboard/widgets/TopCategories.test.tsx
+++ b/test/pages/dashboard/widgets/TopCategories.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TopCategories } from "@/pages/dashboard/widgets/TopCategories";
+import type { DashboardCategorySlice } from "@/types/dashboard";
+
+afterEach(() => cleanup());
+
+const SLICES: DashboardCategorySlice[] = [
+  { label: "Food > Groceries", value: 500 },
+  { label: "Home > Rent/Mortgage", value: 2000 },
+  { label: "Transport > Gas/Fuel", value: 200 },
+  { label: "Food > Dining Out", value: 150 },
+  { label: "Shopping > Clothing", value: 100 },
+  { label: "Entertainment > Subscriptions", value: 80 },
+  { label: "Health > Medical", value: 50 },
+];
+
+test("TopCategories renders at most 5 items", () => {
+  render(<TopCategories categorySlices={SLICES} size="lg" />);
+  // Should show top 5 (already sorted descending by selector)
+  expect(screen.getByText("Home > Rent/Mortgage")).toBeInTheDocument();
+  expect(screen.getByText("Food > Groceries")).toBeInTheDocument();
+  expect(screen.getByText("Transport > Gas/Fuel")).toBeInTheDocument();
+  expect(screen.getByText("Food > Dining Out")).toBeInTheDocument();
+  expect(screen.getByText("Shopping > Clothing")).toBeInTheDocument();
+  // 6th and 7th should not render
+  expect(screen.queryByText("Entertainment > Subscriptions")).toBeNull();
+  expect(screen.queryByText("Health > Medical")).toBeNull();
+});
+
+test("TopCategories shows empty state when no data", () => {
+  render(<TopCategories categorySlices={[]} size="lg" />);
+  expect(screen.getByText(/no.*data|no.*categories/i)).toBeInTheDocument();
+});
+
+test("TopCategories displays amounts", () => {
+  render(<TopCategories categorySlices={SLICES.slice(0, 2)} size="lg" />);
+  expect(screen.getByText("$2,000.00")).toBeInTheDocument();
+  expect(screen.getByText("$500.00")).toBeInTheDocument();
+});
+
+test("TopCategories displays percentages", () => {
+  // Total = 2500, Rent = 2000 = 80%, Groceries = 500 = 20%
+  render(<TopCategories categorySlices={SLICES.slice(0, 2)} size="lg" />);
+  expect(screen.getByText("80%")).toBeInTheDocument();
+  expect(screen.getByText("20%")).toBeInTheDocument();
+});


### PR DESCRIPTION
Add five new dashboard widgets leveraging the hierarchical category system:
- Spend by Category: horizontal bar chart grouped by parent category
- Category Trends: month-over-month comparison (single month) / line chart (multi-month)
- Daily Spending Heatmap: GitHub-style calendar grid with transaction detail panel
- Top Categories: ranked list (registered but not in layout)
- Expense by Owner: redesigned with settlement hero, proportion bar, expandable details

New selectors: buildParentCategoryBreakdown, buildCategoryTrends, buildCategoryComparison, buildDailySpending. Category breakdown and parent category selectors now support multi-month aggregation via monthKeys.

Includes responsive mobile layouts, TDD with 40+ new tests, and widget registry updates.